### PR TITLE
Registry Cleanup

### DIFF
--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
@@ -31,7 +31,6 @@ public class TerrestriaBlocks {
 	public static WoodBlocks JAPANESE_MAPLE;
 	public static WoodBlocks RAINBOW_EUCALYPTUS;
 	public static WoodBlocks SAKURA;
-	public static WoodBlocks PALM;
 
 	public static LeavesBlock JAPANESE_MAPLE_SHRUB_LEAVES;
 	public static LeavesBlock DARK_JAPANESE_MAPLE_LEAVES;

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
@@ -3,9 +3,7 @@ package net.coderbot.terrestria.init;
 import io.github.terraformersmc.terraform.block.*;
 import io.github.terraformersmc.terraform.util.TerraformLargeSaplingGenerator;
 import io.github.terraformersmc.terraform.util.TerraformSaplingGenerator;
-import net.coderbot.terrestria.Terrestria;
 import net.coderbot.terrestria.block.BasaltFlowerBlock;
-import net.coderbot.terrestria.feature.TreeDefinition;
 import net.coderbot.terrestria.init.helpers.TerrestriaRegistry;
 import net.coderbot.terrestria.init.helpers.WoodBlocks;
 import net.coderbot.terrestria.init.helpers.WoodColors;
@@ -13,12 +11,8 @@ import net.fabricmc.fabric.api.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.minecraft.block.*;
 import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
 import net.minecraft.world.gen.feature.JungleTreeFeature;
-
-import java.util.function.Supplier;
 
 // This class exports public block constants, these fields have to be public
 @SuppressWarnings("WeakerAccess")
@@ -94,19 +88,19 @@ public class TerrestriaBlocks {
 		RAINBOW_EUCALYPTUS = WoodBlocks.register("rainbow_eucalyptus", WoodColors.RAINBOW_EUCALYPTUS, flammable);
 		SAKURA = WoodBlocks.register("sakura", WoodColors.SAKURA, flammable, WoodBlocks.LogSize.SMALL);
 
-		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.registerBlock("japanese_maple_shrub_leaves", new LeavesBlock(Block.Settings.copy(Blocks.OAK_LEAVES)));
+		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.register("japanese_maple_shrub_leaves", new LeavesBlock(Block.Settings.copy(Blocks.OAK_LEAVES)));
 
-		DARK_JAPANESE_MAPLE_LEAVES = TerrestriaRegistry.registerBlock("dark_japanese_maple_leaves",
+		DARK_JAPANESE_MAPLE_LEAVES = TerrestriaRegistry.register("dark_japanese_maple_leaves",
 				new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(MaterialColor.RED_TERRACOTTA).build())
 		);
 
-		SAKURA_LEAF_PILE = TerrestriaRegistry.registerBlock("sakura_leaf_pile", new LeafPileBlock(Block.Settings.copy(SAKURA.leaves).noCollision()));
+		SAKURA_LEAF_PILE = TerrestriaRegistry.register("sakura_leaf_pile", new LeafPileBlock(Block.Settings.copy(SAKURA.leaves).noCollision()));
 
 		flammable.add(JAPANESE_MAPLE_SHRUB_LEAVES, 30, 60);
 		flammable.add(SAKURA_LEAF_PILE, 30, 60);
 
-		TALL_CATTAIL = TerrestriaRegistry.registerBlock("tall_cattail", new TallCattailBlock(() -> TerrestriaItems.CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
-		CATTAIL = TerrestriaRegistry.registerBlock("cattail", new TerraformSeagrassBlock(TALL_CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
+		TALL_CATTAIL = TerrestriaRegistry.register("tall_cattail", new TallCattailBlock(() -> TerrestriaItems.CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
+		CATTAIL = TerrestriaRegistry.register("cattail", new TerraformSeagrassBlock(TALL_CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
 
 		REDWOOD_QUARTER_LOG = REDWOOD.registerQuarterLog(() -> STRIPPED_REDWOOD_QUARTER_LOG, flammable);
 		HEMLOCK_QUARTER_LOG = HEMLOCK.registerQuarterLog(() -> STRIPPED_HEMLOCK_QUARTER_LOG, flammable);
@@ -119,50 +113,50 @@ public class TerrestriaBlocks {
 
 		// Saplings
 
-		REDWOOD_SAPLING = TerrestriaRegistry.registerBlock("redwood_sapling", new TerraformSaplingBlock(
+		REDWOOD_SAPLING = TerrestriaRegistry.register("redwood_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.REDWOOD_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_REDWOOD_TREE.sapling()
 				)
 		));
 
-		HEMLOCK_SAPLING = TerrestriaRegistry.registerBlock("hemlock_sapling", new TerraformSaplingBlock(
+		HEMLOCK_SAPLING = TerrestriaRegistry.register("hemlock_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.HEMLOCK_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_HEMLOCK_TREE.sapling()
 				)
 		));
 
-		RUBBER_SAPLING = TerrestriaRegistry.registerBlock("rubber_sapling", new TerraformSaplingBlock(
+		RUBBER_SAPLING = TerrestriaRegistry.register("rubber_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(
 						() -> TerrestriaFeatures.RUBBER_TREE.sapling()
 				)
 		));
 
-		CYPRESS_SAPLING = TerrestriaRegistry.registerBlock("cypress_sapling", new TerraformSaplingBlock(
+		CYPRESS_SAPLING = TerrestriaRegistry.register("cypress_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.CYPRESS_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_CYPRESS_TREE.sapling()
 				)
 		));
 
-		WILLOW_SAPLING = TerrestriaRegistry.registerBlock("willow_sapling", new TerraformSaplingBlock(
+		WILLOW_SAPLING = TerrestriaRegistry.register("willow_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.WILLOW_TREE.sapling())
 		));
 
-		JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("japanese_maple_sapling", new TerraformSaplingBlock(
+		JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.register("japanese_maple_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.JAPANESE_MAPLE_TREE.sapling())
 		));
 
-		JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.registerBlock("japanese_maple_shrub_sapling", new TerraformSaplingBlock(
+		JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.register("japanese_maple_shrub_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.JAPANESE_MAPLE_SHRUB.sapling())
 		));
 
-		DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("dark_japanese_maple_sapling", new TerraformSaplingBlock(
+		DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.register("dark_japanese_maple_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.DARK_JAPANESE_MAPLE_TREE.sapling())
 		));
 
-		RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.registerBlock("rainbow_eucalyptus_sapling", new TerraformSaplingBlock(
+		RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.register("rainbow_eucalyptus_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> new JungleTreeFeature(DefaultFeatureConfig::deserialize, true, 5,
 								TerrestriaBlocks.RAINBOW_EUCALYPTUS.log.getDefaultState(),
@@ -173,38 +167,37 @@ public class TerrestriaBlocks {
 				)
 		));
 
-		SAKURA_SAPLING = TerrestriaRegistry.registerBlock("sakura_sapling", new TerraformSaplingBlock(
+		SAKURA_SAPLING = TerrestriaRegistry.register("sakura_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.SAKURA_TREE.sapling())
 		));
 
-		PALM_SAPLING = TerrestriaRegistry.registerBlock("palm_sapling", new TerraformSaplingBlock(
+		PALM_SAPLING = TerrestriaRegistry.register("palm_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.PALM_TREE.sapling())
 		));
 
 		// Volcanic Island Blocks
 
-		BASALT_SAND = TerrestriaRegistry.registerBlock("basalt_sand", new SandBlock(0x202020, FabricBlockSettings.copy(Blocks.SAND).materialColor(MaterialColor.BLACK).build()));
-		BASALT_DIRT = TerrestriaRegistry.registerBlock("basalt_dirt", new Block(FabricBlockSettings.copy(Blocks.DIRT).materialColor(MaterialColor.BLACK).build()));
-		BASALT_GRASS_BLOCK = TerrestriaRegistry.registerBlock("basalt_grass_block", new TerraformGrassBlock(BASALT_DIRT, Block.Settings.copy(Blocks.GRASS_BLOCK)));
-		BASALT = TerrestriaRegistry.registerBlock("basalt", new Block(FabricBlockSettings.copy(Blocks.STONE).materialColor(MaterialColor.BLACK).build()));
+		BASALT_SAND = TerrestriaRegistry.register("basalt_sand", new SandBlock(0x202020, FabricBlockSettings.copy(Blocks.SAND).materialColor(MaterialColor.BLACK).build()));
+		BASALT_DIRT = TerrestriaRegistry.register("basalt_dirt", new Block(FabricBlockSettings.copy(Blocks.DIRT).materialColor(MaterialColor.BLACK).build()));
+		BASALT_GRASS_BLOCK = TerrestriaRegistry.register("basalt_grass_block", new TerraformGrassBlock(BASALT_DIRT, Block.Settings.copy(Blocks.GRASS_BLOCK)));
+		BASALT = TerrestriaRegistry.register("basalt", new Block(FabricBlockSettings.copy(Blocks.STONE).materialColor(MaterialColor.BLACK).build()));
 
-		INDIAN_PAINTBRUSH = TerrestriaRegistry.registerBlock("indian_paintbrush", new BasaltFlowerBlock(StatusEffects.SATURATION, 6, Block.Settings.copy(Blocks.POPPY)));
-		MONSTERAS = TerrestriaRegistry.registerBlock("monsteras", new BasaltFlowerBlock(StatusEffects.REGENERATION, 2, Block.Settings.copy(Blocks.POPPY)));
+		INDIAN_PAINTBRUSH = TerrestriaRegistry.register("indian_paintbrush", new BasaltFlowerBlock(StatusEffects.SATURATION, 6, Block.Settings.copy(Blocks.POPPY)));
+		MONSTERAS = TerrestriaRegistry.register("monsteras", new BasaltFlowerBlock(StatusEffects.REGENERATION, 2, Block.Settings.copy(Blocks.POPPY)));
 
-		POTTED_INDIAN_PAINTBRUSH = TerrestriaRegistry.registerBlock("potted_indian_paintbrush", new FlowerPotBlock(INDIAN_PAINTBRUSH, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_MONSTERAS = TerrestriaRegistry.registerBlock("potted_monsteras", new FlowerPotBlock(MONSTERAS, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_INDIAN_PAINTBRUSH = TerrestriaRegistry.register("potted_indian_paintbrush", new FlowerPotBlock(INDIAN_PAINTBRUSH, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_MONSTERAS = TerrestriaRegistry.register("potted_monsteras", new FlowerPotBlock(MONSTERAS, Block.Settings.copy(Blocks.POTTED_POPPY)));
 
-		POTTED_REDWOOD_SAPLING = TerrestriaRegistry.registerBlock("potted_redwood_sapling", new FlowerPotBlock(REDWOOD_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_HEMLOCK_SAPLING = TerrestriaRegistry.registerBlock("potted_hemlock_sapling", new FlowerPotBlock(HEMLOCK_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_RUBBER_SAPLING = TerrestriaRegistry.registerBlock("potted_rubber_sapling", new FlowerPotBlock(RUBBER_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_CYPRESS_SAPLING = TerrestriaRegistry.registerBlock("potted_cypress_sapling", new FlowerPotBlock(CYPRESS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_WILLOW_SAPLING = TerrestriaRegistry.registerBlock("potted_willow_sapling", new FlowerPotBlock(WILLOW_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("potted_japanese_maple_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.registerBlock("potted_japanese_maple_shrub_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SHRUB_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("potted_dark_japanese_maple_sapling", new FlowerPotBlock(DARK_JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.registerBlock("potted_rainbow_eucalyptus_sapling", new FlowerPotBlock(RAINBOW_EUCALYPTUS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_SAKURA_SAPLING = TerrestriaRegistry.registerBlock("potted_sakura_sapling", new FlowerPotBlock(SAKURA_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_PALM_SAPLING = TerrestriaRegistry.registerBlock("potted_palm_sapling", new FlowerPotBlock(PALM_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		// TODO: Stripped Logs, Stripped Wood
+		POTTED_REDWOOD_SAPLING = TerrestriaRegistry.register("potted_redwood_sapling", new FlowerPotBlock(REDWOOD_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_HEMLOCK_SAPLING = TerrestriaRegistry.register("potted_hemlock_sapling", new FlowerPotBlock(HEMLOCK_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_RUBBER_SAPLING = TerrestriaRegistry.register("potted_rubber_sapling", new FlowerPotBlock(RUBBER_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_CYPRESS_SAPLING = TerrestriaRegistry.register("potted_cypress_sapling", new FlowerPotBlock(CYPRESS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_WILLOW_SAPLING = TerrestriaRegistry.register("potted_willow_sapling", new FlowerPotBlock(WILLOW_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.register("potted_japanese_maple_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.register("potted_japanese_maple_shrub_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SHRUB_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.register("potted_dark_japanese_maple_sapling", new FlowerPotBlock(DARK_JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.register("potted_rainbow_eucalyptus_sapling", new FlowerPotBlock(RAINBOW_EUCALYPTUS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_SAKURA_SAPLING = TerrestriaRegistry.register("potted_sakura_sapling", new FlowerPotBlock(SAKURA_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_PALM_SAPLING = TerrestriaRegistry.register("potted_palm_sapling", new FlowerPotBlock(PALM_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
 	}
 }

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
@@ -93,7 +93,6 @@ public class TerrestriaBlocks {
 		WILLOW = WoodBlocks.register("willow", WoodColors.WILLOW, flammable);
 		JAPANESE_MAPLE = WoodBlocks.register("japanese_maple", WoodColors.JAPANESE_MAPLE, flammable);
 		RAINBOW_EUCALYPTUS = WoodBlocks.register("rainbow_eucalyptus", WoodColors.RAINBOW_EUCALYPTUS, flammable);
-		PALM = WoodBlocks.register("palm", WoodColors.CYPRESS, flammable);
 		SAKURA = WoodBlocks.register("sakura", WoodColors.SAKURA, flammable, WoodBlocks.LogSize.SMALL);
 
 		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.registerBlock("japanese_maple_shrub_leaves", new LeavesBlock(Block.Settings.copy(Blocks.OAK_LEAVES)));

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaBlocks.java
@@ -6,6 +6,9 @@ import io.github.terraformersmc.terraform.util.TerraformSaplingGenerator;
 import net.coderbot.terrestria.Terrestria;
 import net.coderbot.terrestria.block.BasaltFlowerBlock;
 import net.coderbot.terrestria.feature.TreeDefinition;
+import net.coderbot.terrestria.init.helpers.TerrestriaRegistry;
+import net.coderbot.terrestria.init.helpers.WoodBlocks;
+import net.coderbot.terrestria.init.helpers.WoodColors;
 import net.fabricmc.fabric.api.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.minecraft.block.*;
@@ -28,6 +31,7 @@ public class TerrestriaBlocks {
 	public static WoodBlocks JAPANESE_MAPLE;
 	public static WoodBlocks RAINBOW_EUCALYPTUS;
 	public static WoodBlocks SAKURA;
+	public static WoodBlocks PALM;
 
 	public static LeavesBlock JAPANESE_MAPLE_SHRUB_LEAVES;
 	public static LeavesBlock DARK_JAPANESE_MAPLE_LEAVES;
@@ -82,35 +86,29 @@ public class TerrestriaBlocks {
 	public static void init() {
 		FlammableBlockRegistry flammable = FlammableBlockRegistry.getDefaultInstance();
 
-		REDWOOD = WoodBlocks.registerExtendedLeaves("redwood", WoodColors.REDWOOD, flammable);
-		HEMLOCK = WoodBlocks.registerExtendedLeaves("hemlock", WoodColors.HEMLOCK, flammable);
+		REDWOOD = WoodBlocks.register("redwood", WoodColors.REDWOOD, flammable, true);
+		HEMLOCK = WoodBlocks.register("hemlock", WoodColors.HEMLOCK, flammable, true);
 		RUBBER = WoodBlocks.register("rubber", WoodColors.RUBBER, flammable);
 		CYPRESS = WoodBlocks.register("cypress", WoodColors.CYPRESS, flammable);
 		WILLOW = WoodBlocks.register("willow", WoodColors.WILLOW, flammable);
 		JAPANESE_MAPLE = WoodBlocks.register("japanese_maple", WoodColors.JAPANESE_MAPLE, flammable);
 		RAINBOW_EUCALYPTUS = WoodBlocks.register("rainbow_eucalyptus", WoodColors.RAINBOW_EUCALYPTUS, flammable);
+		PALM = WoodBlocks.register("palm", WoodColors.CYPRESS, flammable);
+		SAKURA = WoodBlocks.register("sakura", WoodColors.SAKURA, flammable, WoodBlocks.LogSize.SMALL);
 
-		SAKURA = WoodBlocks.registerManufactured("sakura", WoodColors.SAKURA, flammable);
-		SAKURA.leaves = register("sakura_leaves", new TransparentLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(WoodColors.SAKURA.leaves).build()));
-		SAKURA.log = register("sakura_log", new SmallLogBlock(SAKURA.leaves, () -> SAKURA.strippedLog, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(WoodColors.SAKURA.bark).build()));
-		SAKURA.strippedLog = register("stripped_sakura_log", new SmallLogBlock(SAKURA.leaves, null, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(WoodColors.SAKURA.planks).build()));
-		SAKURA.wood = SAKURA.log;
-		SAKURA.strippedWood = SAKURA.strippedLog;
-		SAKURA.addTreeFireInfo(flammable);
+		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.registerBlock("japanese_maple_shrub_leaves", new LeavesBlock(Block.Settings.copy(Blocks.OAK_LEAVES)));
 
-		JAPANESE_MAPLE_SHRUB_LEAVES = register("japanese_maple_shrub_leaves", new LeavesBlock(Block.Settings.copy(Blocks.OAK_LEAVES)));
-
-		DARK_JAPANESE_MAPLE_LEAVES = register("dark_japanese_maple_leaves",
+		DARK_JAPANESE_MAPLE_LEAVES = TerrestriaRegistry.registerBlock("dark_japanese_maple_leaves",
 				new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(MaterialColor.RED_TERRACOTTA).build())
 		);
 
-		SAKURA_LEAF_PILE = register("sakura_leaf_pile", new LeafPileBlock(Block.Settings.copy(SAKURA.leaves).noCollision()));
+		SAKURA_LEAF_PILE = TerrestriaRegistry.registerBlock("sakura_leaf_pile", new LeafPileBlock(Block.Settings.copy(SAKURA.leaves).noCollision()));
 
 		flammable.add(JAPANESE_MAPLE_SHRUB_LEAVES, 30, 60);
 		flammable.add(SAKURA_LEAF_PILE, 30, 60);
 
-		TALL_CATTAIL = register("tall_cattail", new TallCattailBlock(() -> TerrestriaItems.CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
-		CATTAIL = register("cattail", new TerraformSeagrassBlock(TALL_CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
+		TALL_CATTAIL = TerrestriaRegistry.registerBlock("tall_cattail", new TallCattailBlock(() -> TerrestriaItems.CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
+		CATTAIL = TerrestriaRegistry.registerBlock("cattail", new TerraformSeagrassBlock(TALL_CATTAIL, Block.Settings.copy(Blocks.SEAGRASS)));
 
 		REDWOOD_QUARTER_LOG = REDWOOD.registerQuarterLog(() -> STRIPPED_REDWOOD_QUARTER_LOG, flammable);
 		HEMLOCK_QUARTER_LOG = HEMLOCK.registerQuarterLog(() -> STRIPPED_HEMLOCK_QUARTER_LOG, flammable);
@@ -123,50 +121,50 @@ public class TerrestriaBlocks {
 
 		// Saplings
 
-		REDWOOD_SAPLING = register("redwood_sapling", new TerraformSaplingBlock(
+		REDWOOD_SAPLING = TerrestriaRegistry.registerBlock("redwood_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.REDWOOD_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_REDWOOD_TREE.sapling()
 				)
 		));
 
-		HEMLOCK_SAPLING = register("hemlock_sapling", new TerraformSaplingBlock(
+		HEMLOCK_SAPLING = TerrestriaRegistry.registerBlock("hemlock_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.HEMLOCK_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_HEMLOCK_TREE.sapling()
 				)
 		));
 
-		RUBBER_SAPLING = register("rubber_sapling", new TerraformSaplingBlock(
+		RUBBER_SAPLING = TerrestriaRegistry.registerBlock("rubber_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(
 						() -> TerrestriaFeatures.RUBBER_TREE.sapling()
 				)
 		));
 
-		CYPRESS_SAPLING = register("cypress_sapling", new TerraformSaplingBlock(
+		CYPRESS_SAPLING = TerrestriaRegistry.registerBlock("cypress_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> TerrestriaFeatures.CYPRESS_TREE.sapling(),
 						() -> TerrestriaFeatures.MEGA_CYPRESS_TREE.sapling()
 				)
 		));
 
-		WILLOW_SAPLING = register("willow_sapling", new TerraformSaplingBlock(
+		WILLOW_SAPLING = TerrestriaRegistry.registerBlock("willow_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.WILLOW_TREE.sapling())
 		));
 
-		JAPANESE_MAPLE_SAPLING = register("japanese_maple_sapling", new TerraformSaplingBlock(
+		JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("japanese_maple_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.JAPANESE_MAPLE_TREE.sapling())
 		));
 
-		JAPANESE_MAPLE_SHRUB_SAPLING = register("japanese_maple_shrub_sapling", new TerraformSaplingBlock(
+		JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.registerBlock("japanese_maple_shrub_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.JAPANESE_MAPLE_SHRUB.sapling())
 		));
 
-		DARK_JAPANESE_MAPLE_SAPLING = register("dark_japanese_maple_sapling", new TerraformSaplingBlock(
+		DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("dark_japanese_maple_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.DARK_JAPANESE_MAPLE_TREE.sapling())
 		));
 
-		RAINBOW_EUCALYPTUS_SAPLING = register("rainbow_eucalyptus_sapling", new TerraformSaplingBlock(
+		RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.registerBlock("rainbow_eucalyptus_sapling", new TerraformSaplingBlock(
 				new TerraformLargeSaplingGenerator(
 						() -> new JungleTreeFeature(DefaultFeatureConfig::deserialize, true, 5,
 								TerrestriaBlocks.RAINBOW_EUCALYPTUS.log.getDefaultState(),
@@ -177,214 +175,38 @@ public class TerrestriaBlocks {
 				)
 		));
 
-		SAKURA_SAPLING = register("sakura_sapling", new TerraformSaplingBlock(
+		SAKURA_SAPLING = TerrestriaRegistry.registerBlock("sakura_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.SAKURA_TREE.sapling())
 		));
 
-		PALM_SAPLING = register("palm_sapling", new TerraformSaplingBlock(
+		PALM_SAPLING = TerrestriaRegistry.registerBlock("palm_sapling", new TerraformSaplingBlock(
 				new TerraformSaplingGenerator(() -> TerrestriaFeatures.PALM_TREE.sapling())
 		));
 
 		// Volcanic Island Blocks
 
-		BASALT_SAND = register("basalt_sand", new SandBlock(0x202020, FabricBlockSettings.copy(Blocks.SAND).materialColor(MaterialColor.BLACK).build()));
-		BASALT_DIRT = register("basalt_dirt", new Block(FabricBlockSettings.copy(Blocks.DIRT).materialColor(MaterialColor.BLACK).build()));
-		BASALT_GRASS_BLOCK = register("basalt_grass_block", new TerraformGrassBlock(BASALT_DIRT, Block.Settings.copy(Blocks.GRASS_BLOCK)));
-		BASALT = register("basalt", new Block(FabricBlockSettings.copy(Blocks.STONE).materialColor(MaterialColor.BLACK).build()));
+		BASALT_SAND = TerrestriaRegistry.registerBlock("basalt_sand", new SandBlock(0x202020, FabricBlockSettings.copy(Blocks.SAND).materialColor(MaterialColor.BLACK).build()));
+		BASALT_DIRT = TerrestriaRegistry.registerBlock("basalt_dirt", new Block(FabricBlockSettings.copy(Blocks.DIRT).materialColor(MaterialColor.BLACK).build()));
+		BASALT_GRASS_BLOCK = TerrestriaRegistry.registerBlock("basalt_grass_block", new TerraformGrassBlock(BASALT_DIRT, Block.Settings.copy(Blocks.GRASS_BLOCK)));
+		BASALT = TerrestriaRegistry.registerBlock("basalt", new Block(FabricBlockSettings.copy(Blocks.STONE).materialColor(MaterialColor.BLACK).build()));
 
-		INDIAN_PAINTBRUSH = register("indian_paintbrush", new BasaltFlowerBlock(StatusEffects.SATURATION, 6, Block.Settings.copy(Blocks.POPPY)));
-		MONSTERAS = register("monsteras", new BasaltFlowerBlock(StatusEffects.REGENERATION, 2, Block.Settings.copy(Blocks.POPPY)));
+		INDIAN_PAINTBRUSH = TerrestriaRegistry.registerBlock("indian_paintbrush", new BasaltFlowerBlock(StatusEffects.SATURATION, 6, Block.Settings.copy(Blocks.POPPY)));
+		MONSTERAS = TerrestriaRegistry.registerBlock("monsteras", new BasaltFlowerBlock(StatusEffects.REGENERATION, 2, Block.Settings.copy(Blocks.POPPY)));
 
-		POTTED_INDIAN_PAINTBRUSH = register("potted_indian_paintbrush", new FlowerPotBlock(INDIAN_PAINTBRUSH, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_MONSTERAS = register("potted_monsteras", new FlowerPotBlock(MONSTERAS, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_INDIAN_PAINTBRUSH = TerrestriaRegistry.registerBlock("potted_indian_paintbrush", new FlowerPotBlock(INDIAN_PAINTBRUSH, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_MONSTERAS = TerrestriaRegistry.registerBlock("potted_monsteras", new FlowerPotBlock(MONSTERAS, Block.Settings.copy(Blocks.POTTED_POPPY)));
 
-		POTTED_REDWOOD_SAPLING = register("potted_redwood_sapling", new FlowerPotBlock(REDWOOD_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_HEMLOCK_SAPLING = register("potted_hemlock_sapling", new FlowerPotBlock(HEMLOCK_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_RUBBER_SAPLING = register("potted_rubber_sapling", new FlowerPotBlock(RUBBER_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_CYPRESS_SAPLING = register("potted_cypress_sapling", new FlowerPotBlock(CYPRESS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_WILLOW_SAPLING = register("potted_willow_sapling", new FlowerPotBlock(WILLOW_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_JAPANESE_MAPLE_SAPLING = register("potted_japanese_maple_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_JAPANESE_MAPLE_SHRUB_SAPLING = register("potted_japanese_maple_shrub_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SHRUB_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_DARK_JAPANESE_MAPLE_SAPLING = register("potted_dark_japanese_maple_sapling", new FlowerPotBlock(DARK_JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_RAINBOW_EUCALYPTUS_SAPLING = register("potted_rainbow_eucalyptus_sapling", new FlowerPotBlock(RAINBOW_EUCALYPTUS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_SAKURA_SAPLING = register("potted_sakura_sapling", new FlowerPotBlock(SAKURA_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
-		POTTED_PALM_SAPLING = register("potted_palm_sapling", new FlowerPotBlock(PALM_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_REDWOOD_SAPLING = TerrestriaRegistry.registerBlock("potted_redwood_sapling", new FlowerPotBlock(REDWOOD_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_HEMLOCK_SAPLING = TerrestriaRegistry.registerBlock("potted_hemlock_sapling", new FlowerPotBlock(HEMLOCK_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_RUBBER_SAPLING = TerrestriaRegistry.registerBlock("potted_rubber_sapling", new FlowerPotBlock(RUBBER_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_CYPRESS_SAPLING = TerrestriaRegistry.registerBlock("potted_cypress_sapling", new FlowerPotBlock(CYPRESS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_WILLOW_SAPLING = TerrestriaRegistry.registerBlock("potted_willow_sapling", new FlowerPotBlock(WILLOW_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("potted_japanese_maple_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.registerBlock("potted_japanese_maple_shrub_sapling", new FlowerPotBlock(JAPANESE_MAPLE_SHRUB_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlock("potted_dark_japanese_maple_sapling", new FlowerPotBlock(DARK_JAPANESE_MAPLE_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.registerBlock("potted_rainbow_eucalyptus_sapling", new FlowerPotBlock(RAINBOW_EUCALYPTUS_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_SAKURA_SAPLING = TerrestriaRegistry.registerBlock("potted_sakura_sapling", new FlowerPotBlock(SAKURA_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
+		POTTED_PALM_SAPLING = TerrestriaRegistry.registerBlock("potted_palm_sapling", new FlowerPotBlock(PALM_SAPLING, Block.Settings.copy(Blocks.POTTED_POPPY)));
 		// TODO: Stripped Logs, Stripped Wood
-	}
-
-	public static <T extends Block> T register(String name, T block) {
-		return Registry.register(Registry.BLOCK, new Identifier(Terrestria.MOD_ID, name), block);
-	}
-
-	public static class WoodColors {
-		public static final WoodColors REDWOOD;
-		public static final WoodColors HEMLOCK;
-		public static final WoodColors RUBBER;
-		public static final WoodColors CYPRESS;
-		public static final WoodColors WILLOW;
-		public static final WoodColors JAPANESE_MAPLE;
-		public static final WoodColors RAINBOW_EUCALYPTUS;
-		public static final WoodColors SAKURA;
-
-		static {
-			REDWOOD = new WoodColors();
-			REDWOOD.bark = MaterialColor.RED_TERRACOTTA;
-			REDWOOD.planks = MaterialColor.WOOD;
-
-			HEMLOCK = new WoodColors();
-			HEMLOCK.bark = MaterialColor.BROWN;
-			HEMLOCK.planks = MaterialColor.WOOD;
-
-			RUBBER = new WoodColors();
-			RUBBER.bark = MaterialColor.WHITE_TERRACOTTA;
-			RUBBER.planks = MaterialColor.SAND;
-
-			CYPRESS = new WoodColors();
-			CYPRESS.bark = MaterialColor.WHITE_TERRACOTTA;
-			CYPRESS.planks = MaterialColor.LIGHT_GRAY;
-
-			WILLOW = new WoodColors();
-			WILLOW.bark = MaterialColor.WHITE_TERRACOTTA;
-			WILLOW.planks = MaterialColor.GRAY;
-			WILLOW.leaves = MaterialColor.LIGHT_GRAY;
-
-			JAPANESE_MAPLE = new WoodColors();
-			JAPANESE_MAPLE.bark = MaterialColor.BROWN;
-			JAPANESE_MAPLE.planks = MaterialColor.MAGENTA_TERRACOTTA;
-			JAPANESE_MAPLE.leaves = MaterialColor.RED;
-
-			RAINBOW_EUCALYPTUS = new WoodColors();
-			RAINBOW_EUCALYPTUS.bark = MaterialColor.BLUE;
-			RAINBOW_EUCALYPTUS.planks = MaterialColor.LAPIS;
-
-			SAKURA = new WoodColors();
-			SAKURA.bark = MaterialColor.SPRUCE;
-			SAKURA.planks = MaterialColor.BROWN;
-			SAKURA.leaves = MaterialColor.PINK;
-		}
-
-		public MaterialColor bark;
-		public MaterialColor planks;
-		public MaterialColor leaves = MaterialColor.FOLIAGE;
-	}
-
-	public static class WoodBlocks {
-		public Block log;
-		public Block wood;
-		public Block leaves;
-		public Block planks;
-		public SlabBlock slab;
-		public TerraformStairsBlock stairs;
-		public FenceBlock fence;
-		public FenceGateBlock fenceGate;
-		public TerraformDoorBlock door;
-		public TerraformButtonBlock button;
-		public TerraformPressurePlateBlock pressurePlate;
-		public TerraformSignBlock sign;
-		public TerraformWallSignBlock wallSign;
-		public TerraformTrapdoorBlock trapdoor;
-		public Block strippedLog;
-		public Block strippedWood;
-		private String name;
-		private WoodColors colors;
-
-		private WoodBlocks() {
-		}
-
-		public static WoodBlocks register(String name, WoodColors colors, FlammableBlockRegistry registry) {
-			WoodBlocks blocks = registerManufactured(name, colors, registry);
-
-			blocks.log = TerrestriaBlocks.register(name + "_log", new StrippableLogBlock(() -> blocks.strippedLog, colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-			blocks.wood = TerrestriaBlocks.register(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-			blocks.leaves = TerrestriaBlocks.register(name + "_leaves", new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
-			blocks.strippedLog = TerrestriaBlocks.register("stripped_" + name + "_log", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-			blocks.strippedWood = TerrestriaBlocks.register("stripped_" + name + "_wood", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-
-			blocks.addTreeFireInfo(registry);
-
-			return blocks;
-		}
-
-		public static WoodBlocks registerExtendedLeaves(String name, WoodColors colors, FlammableBlockRegistry registry) {
-			WoodBlocks blocks = registerManufactured(name, colors, registry);
-
-			blocks.log = TerrestriaBlocks.register(name + "_log", new StrippableLogBlock(() -> blocks.strippedLog, colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-			blocks.wood = TerrestriaBlocks.register(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-			blocks.leaves = TerrestriaBlocks.register(name + "_leaves", new ExtendedLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
-			blocks.strippedLog = TerrestriaBlocks.register("stripped_" + name + "_log", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-			blocks.strippedWood = TerrestriaBlocks.register("stripped_" + name + "_wood", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-
-			blocks.addTreeFireInfo(registry);
-
-			return blocks;
-		}
-
-		public static WoodBlocks registerManufactured(String name, WoodColors colors, FlammableBlockRegistry registry) {
-			WoodBlocks blocks = new WoodBlocks();
-			blocks.name = name;
-			blocks.colors = colors;
-
-			blocks.planks = TerrestriaBlocks.register(name + "_planks", new Block(FabricBlockSettings.copy(Blocks.OAK_PLANKS).materialColor(colors.planks).build()));
-			blocks.slab = TerrestriaBlocks.register(name + "_slab", new SlabBlock(FabricBlockSettings.copy(Blocks.OAK_SLAB).materialColor(colors.planks).build()));
-			blocks.stairs = TerrestriaBlocks.register(name + "_stairs", new TerraformStairsBlock(blocks.planks, FabricBlockSettings.copy(Blocks.OAK_STAIRS).materialColor(colors.planks).build()));
-			blocks.fence = TerrestriaBlocks.register(name + "_fence", new FenceBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE).materialColor(colors.planks).build()));
-			blocks.fenceGate = TerrestriaBlocks.register(name + "_fence_gate", new FenceGateBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
-			blocks.door = TerrestriaBlocks.register(name + "_door", new TerraformDoorBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
-			blocks.button = TerrestriaBlocks.register(name + "_button", new TerraformButtonBlock(FabricBlockSettings.copy(Blocks.OAK_BUTTON).materialColor(colors.planks).build()));
-			blocks.pressurePlate = TerrestriaBlocks.register(name + "_pressure_plate", new TerraformPressurePlateBlock(FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).materialColor(colors.planks).build()));
-			blocks.trapdoor = TerrestriaBlocks.register(name + "_trapdoor", new TerraformTrapdoorBlock(FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).materialColor(colors.planks).build()));
-
-			Identifier signTexture = new Identifier(Terrestria.MOD_ID, "textures/entity/signs/" + name + ".png");
-
-			blocks.sign = TerrestriaBlocks.register(name + "_sign", new TerraformSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
-			blocks.wallSign = TerrestriaBlocks.register(name + "_wall_sign", new TerraformWallSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
-
-			blocks.addManufacturedFireInfo(registry);
-
-			return blocks;
-		}
-
-		public QuarterLogBlock registerQuarterLog(Supplier<Block> stripped, FlammableBlockRegistry registry) {
-			QuarterLogBlock quarterLog = TerrestriaBlocks.register(name + "_quarter_log", new QuarterLogBlock(stripped, colors.planks, Block.Settings.copy(log)));
-
-			registry.add(quarterLog, 5, 5);
-
-			return quarterLog;
-		}
-
-		public QuarterLogBlock registerStrippedQuarterLog(FlammableBlockRegistry registry) {
-			QuarterLogBlock quarterLog = TerrestriaBlocks.register("stripped_" + name + "_quarter_log", new QuarterLogBlock(null, colors.planks, Block.Settings.copy(strippedLog)));
-
-			registry.add(quarterLog, 5, 5);
-
-			return quarterLog;
-		}
-
-		public void addTreeFireInfo(FlammableBlockRegistry registry) {
-			registry.add(log, 5, 5);
-			registry.add(strippedLog, 5, 5);
-
-			if (wood != log) {
-				registry.add(wood, 5, 5);
-			}
-
-			if (strippedWood != strippedLog) {
-				registry.add(strippedWood, 5, 5);
-			}
-
-			registry.add(leaves, 30, 60);
-		}
-
-		public void addManufacturedFireInfo(FlammableBlockRegistry registry) {
-			registry.add(planks, 5, 20);
-			registry.add(slab, 5, 20);
-			registry.add(stairs, 5, 20);
-			registry.add(fence, 5, 20);
-			registry.add(fenceGate, 5, 20);
-		}
-
-		public TreeDefinition.Basic getBasicDefinition() {
-			return new TreeDefinition.Basic(this.log.getDefaultState(), this.leaves.getDefaultState());
-		}
 	}
 }

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaFeatures.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaFeatures.java
@@ -146,7 +146,7 @@ public class TerrestriaFeatures {
 		// TODO: palm wood
 		TreeDefinition.Basic palmDefinition = new TreeDefinition.Basic(
 				Blocks.JUNGLE_LOG.getDefaultState(),
-				TerrestriaBlocks.PALM.leaves.getDefaultState()
+				Blocks.JUNGLE_LEAVES.getDefaultState()
 		);
 
 		PALM_TREE = register("palm_tree",

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaFeatures.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaFeatures.java
@@ -146,7 +146,7 @@ public class TerrestriaFeatures {
 		// TODO: palm wood
 		TreeDefinition.Basic palmDefinition = new TreeDefinition.Basic(
 				Blocks.JUNGLE_LOG.getDefaultState(),
-				Blocks.JUNGLE_LEAVES.getDefaultState()
+				TerrestriaBlocks.PALM.leaves.getDefaultState()
 		);
 
 		PALM_TREE = register("palm_tree",

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
@@ -15,7 +15,6 @@ public class TerrestriaItems {
 	public static WoodItems JAPANESE_MAPLE;
 	public static WoodItems RAINBOW_EUCALYPTUS;
 	public static WoodItems SAKURA;
-	public static WoodItems PALM;
 
 	public static BlockItem JAPANESE_MAPLE_SHRUB_LEAVES;
 	public static BlockItem DARK_JAPANESE_MAPLE_LEAVES;
@@ -59,7 +58,7 @@ public class TerrestriaItems {
 		WILLOW = WoodItems.register("willow", TerrestriaBlocks.WILLOW);
 		JAPANESE_MAPLE = WoodItems.register("japanese_maple", TerrestriaBlocks.JAPANESE_MAPLE);
 		RAINBOW_EUCALYPTUS = WoodItems.register("rainbow_eucalyptus", TerrestriaBlocks.RAINBOW_EUCALYPTUS);
-		SAKURA = WoodItems.registerWithoutBark("sakura", TerrestriaBlocks.SAKURA);
+		SAKURA = WoodItems.register("sakura", TerrestriaBlocks.SAKURA);
 		SAKURA.wood = SAKURA.log;
 
 		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.registerBlockItem("japanese_maple_shrub_leaves", TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_LEAVES);

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
@@ -1,12 +1,8 @@
 package net.coderbot.terrestria.init;
 
-import net.coderbot.terrestria.Terrestria;
-import net.minecraft.block.Block;
+import net.coderbot.terrestria.init.helpers.TerrestriaRegistry;
+import net.coderbot.terrestria.init.helpers.WoodItems;
 import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.SignItem;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
 // This class exports public item constants, these fields have to be public
 @SuppressWarnings("WeakerAccess")
@@ -19,6 +15,7 @@ public class TerrestriaItems {
 	public static WoodItems JAPANESE_MAPLE;
 	public static WoodItems RAINBOW_EUCALYPTUS;
 	public static WoodItems SAKURA;
+	public static WoodItems PALM;
 
 	public static BlockItem JAPANESE_MAPLE_SHRUB_LEAVES;
 	public static BlockItem DARK_JAPANESE_MAPLE_LEAVES;
@@ -62,100 +59,43 @@ public class TerrestriaItems {
 		WILLOW = WoodItems.register("willow", TerrestriaBlocks.WILLOW);
 		JAPANESE_MAPLE = WoodItems.register("japanese_maple", TerrestriaBlocks.JAPANESE_MAPLE);
 		RAINBOW_EUCALYPTUS = WoodItems.register("rainbow_eucalyptus", TerrestriaBlocks.RAINBOW_EUCALYPTUS);
+		PALM = WoodItems.register("palm", TerrestriaBlocks.PALM);
 		SAKURA = WoodItems.registerWithoutBark("sakura", TerrestriaBlocks.SAKURA);
 		SAKURA.wood = SAKURA.log;
 
-		JAPANESE_MAPLE_SHRUB_LEAVES = register("japanese_maple_shrub_leaves", TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_LEAVES);
-		DARK_JAPANESE_MAPLE_LEAVES = register("dark_japanese_maple_leaves", TerrestriaBlocks.DARK_JAPANESE_MAPLE_LEAVES);
-		SAKURA_LEAF_PILE = register("sakura_leaf_pile", TerrestriaBlocks.SAKURA_LEAF_PILE);
+		JAPANESE_MAPLE_SHRUB_LEAVES = TerrestriaRegistry.registerBlockItem("japanese_maple_shrub_leaves", TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_LEAVES);
+		DARK_JAPANESE_MAPLE_LEAVES = TerrestriaRegistry.registerBlockItem("dark_japanese_maple_leaves", TerrestriaBlocks.DARK_JAPANESE_MAPLE_LEAVES);
+		SAKURA_LEAF_PILE = TerrestriaRegistry.registerBlockItem("sakura_leaf_pile", TerrestriaBlocks.SAKURA_LEAF_PILE);
 
-		CATTAIL = register("cattail", TerrestriaBlocks.CATTAIL);
+		CATTAIL = TerrestriaRegistry.registerBlockItem("cattail", TerrestriaBlocks.CATTAIL);
 
-		REDWOOD_QUARTER_LOG = register("redwood_quarter_log", TerrestriaBlocks.REDWOOD_QUARTER_LOG);
-		HEMLOCK_QUARTER_LOG = register("hemlock_quarter_log", TerrestriaBlocks.HEMLOCK_QUARTER_LOG);
-		CYPRESS_QUARTER_LOG = register("cypress_quarter_log", TerrestriaBlocks.CYPRESS_QUARTER_LOG);
-		RAINBOW_EUCALYPTUS_QUARTER_LOG = register("rainbow_eucalyptus_quarter_log", TerrestriaBlocks.RAINBOW_EUCALYPTUS_QUARTER_LOG);
+		REDWOOD_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("redwood_quarter_log", TerrestriaBlocks.REDWOOD_QUARTER_LOG);
+		HEMLOCK_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("hemlock_quarter_log", TerrestriaBlocks.HEMLOCK_QUARTER_LOG);
+		CYPRESS_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("cypress_quarter_log", TerrestriaBlocks.CYPRESS_QUARTER_LOG);
+		RAINBOW_EUCALYPTUS_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("rainbow_eucalyptus_quarter_log", TerrestriaBlocks.RAINBOW_EUCALYPTUS_QUARTER_LOG);
 
-		STRIPPED_REDWOOD_QUARTER_LOG = register("stripped_redwood_quarter_log", TerrestriaBlocks.STRIPPED_REDWOOD_QUARTER_LOG);
-		STRIPPED_HEMLOCK_QUARTER_LOG = register("stripped_hemlock_quarter_log", TerrestriaBlocks.STRIPPED_HEMLOCK_QUARTER_LOG);
-		STRIPPED_CYPRESS_QUARTER_LOG = register("stripped_cypress_quarter_log", TerrestriaBlocks.STRIPPED_CYPRESS_QUARTER_LOG);
-		STRIPPED_RAINBOW_EUCALYPTUS_QUARTER_LOG = register("stripped_rainbow_eucalyptus_quarter_log", TerrestriaBlocks.STRIPPED_RAINBOW_EUCALYPTUS_QUARTER_LOG);
+		STRIPPED_REDWOOD_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("stripped_redwood_quarter_log", TerrestriaBlocks.STRIPPED_REDWOOD_QUARTER_LOG);
+		STRIPPED_HEMLOCK_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("stripped_hemlock_quarter_log", TerrestriaBlocks.STRIPPED_HEMLOCK_QUARTER_LOG);
+		STRIPPED_CYPRESS_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("stripped_cypress_quarter_log", TerrestriaBlocks.STRIPPED_CYPRESS_QUARTER_LOG);
+		STRIPPED_RAINBOW_EUCALYPTUS_QUARTER_LOG = TerrestriaRegistry.registerBlockItem("stripped_rainbow_eucalyptus_quarter_log", TerrestriaBlocks.STRIPPED_RAINBOW_EUCALYPTUS_QUARTER_LOG);
 
-		REDWOOD_SAPLING = register("redwood_sapling", TerrestriaBlocks.REDWOOD_SAPLING);
-		HEMLOCK_SAPLING = register("hemlock_sapling", TerrestriaBlocks.HEMLOCK_SAPLING);
-		RUBBER_SAPLING = register("rubber_sapling", TerrestriaBlocks.RUBBER_SAPLING);
-		CYPRESS_SAPLING = register("cypress_sapling", TerrestriaBlocks.CYPRESS_SAPLING);
-		WILLOW_SAPLING = register("willow_sapling", TerrestriaBlocks.WILLOW_SAPLING);
-		JAPANESE_MAPLE_SAPLING = register("japanese_maple_sapling", TerrestriaBlocks.JAPANESE_MAPLE_SAPLING);
-		JAPANESE_MAPLE_SHRUB_SAPLING = register("japanese_maple_shrub_sapling", TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_SAPLING);
-		DARK_JAPANESE_MAPLE_SAPLING = register("dark_japanese_maple_sapling", TerrestriaBlocks.DARK_JAPANESE_MAPLE_SAPLING);
-		RAINBOW_EUCALYPTUS_SAPLING = register("rainbow_eucalyptus_sapling", TerrestriaBlocks.RAINBOW_EUCALYPTUS_SAPLING);
-		SAKURA_SAPLING = register("sakura_sapling", TerrestriaBlocks.SAKURA_SAPLING);
-		PALM_SAPLING = register("palm_sapling", TerrestriaBlocks.PALM_SAPLING);
+		REDWOOD_SAPLING = TerrestriaRegistry.registerBlockItem("redwood_sapling", TerrestriaBlocks.REDWOOD_SAPLING);
+		HEMLOCK_SAPLING = TerrestriaRegistry.registerBlockItem("hemlock_sapling", TerrestriaBlocks.HEMLOCK_SAPLING);
+		RUBBER_SAPLING = TerrestriaRegistry.registerBlockItem("rubber_sapling", TerrestriaBlocks.RUBBER_SAPLING);
+		CYPRESS_SAPLING = TerrestriaRegistry.registerBlockItem("cypress_sapling", TerrestriaBlocks.CYPRESS_SAPLING);
+		WILLOW_SAPLING = TerrestriaRegistry.registerBlockItem("willow_sapling", TerrestriaBlocks.WILLOW_SAPLING);
+		JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlockItem("japanese_maple_sapling", TerrestriaBlocks.JAPANESE_MAPLE_SAPLING);
+		JAPANESE_MAPLE_SHRUB_SAPLING = TerrestriaRegistry.registerBlockItem("japanese_maple_shrub_sapling", TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_SAPLING);
+		DARK_JAPANESE_MAPLE_SAPLING = TerrestriaRegistry.registerBlockItem("dark_japanese_maple_sapling", TerrestriaBlocks.DARK_JAPANESE_MAPLE_SAPLING);
+		RAINBOW_EUCALYPTUS_SAPLING = TerrestriaRegistry.registerBlockItem("rainbow_eucalyptus_sapling", TerrestriaBlocks.RAINBOW_EUCALYPTUS_SAPLING);
+		SAKURA_SAPLING = TerrestriaRegistry.registerBlockItem("sakura_sapling", TerrestriaBlocks.SAKURA_SAPLING);
+		PALM_SAPLING = TerrestriaRegistry.registerBlockItem("palm_sapling", TerrestriaBlocks.PALM_SAPLING);
 
-		BASALT = register("basalt", TerrestriaBlocks.BASALT);
-		BASALT_SAND = register("basalt_sand", TerrestriaBlocks.BASALT_SAND);
-		BASALT_DIRT = register("basalt_dirt", TerrestriaBlocks.BASALT_DIRT);
-		BASALT_GRASS_BLOCK = register("basalt_grass_block", TerrestriaBlocks.BASALT_GRASS_BLOCK);
-		INDIAN_PAINTBRUSH = register("indian_paintbrush", TerrestriaBlocks.INDIAN_PAINTBRUSH);
-		MONSTERAS = register("monsteras", TerrestriaBlocks.MONSTERAS);
-	}
-
-	private static BlockItem register(String name, Block block) {
-		return Registry.register(Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new BlockItem(block, new Item.Settings().group(Terrestria.ITEM_GROUP)));
-	}
-
-	private static SignItem registerSign(String name, Block standing, Block wall) {
-		return Registry.register(Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new SignItem(new Item.Settings().group(Terrestria.ITEM_GROUP), standing, wall));
-	}
-
-	public static class WoodItems {
-		public BlockItem log;
-		public BlockItem wood;
-		public BlockItem leaves;
-		public BlockItem planks;
-		public BlockItem slab;
-		public BlockItem stairs;
-		public BlockItem fence;
-		public BlockItem fenceGate;
-		public BlockItem door;
-		public BlockItem button;
-		public BlockItem pressurePlate;
-		public SignItem sign;
-		public BlockItem trapdoor;
-		public BlockItem strippedLog;
-		public BlockItem strippedWood;
-
-		private WoodItems() {
-		}
-
-		public static WoodItems register(String name, TerrestriaBlocks.WoodBlocks blocks) {
-			WoodItems items = registerWithoutBark(name, blocks);
-
-			items.wood = TerrestriaItems.register(name + "_wood", blocks.wood);
-			items.strippedWood = TerrestriaItems.register("stripped_" + name + "_wood", blocks.strippedWood);
-
-			return items;
-		}
-
-		public static WoodItems registerWithoutBark(String name, TerrestriaBlocks.WoodBlocks blocks) {
-			WoodItems items = new WoodItems();
-
-			items.log = TerrestriaItems.register(name + "_log", blocks.log);
-			items.leaves = TerrestriaItems.register(name + "_leaves", blocks.leaves);
-			items.planks = TerrestriaItems.register(name + "_planks", blocks.planks);
-			items.slab = TerrestriaItems.register(name + "_slab", blocks.slab);
-			items.stairs = TerrestriaItems.register(name + "_stairs", blocks.stairs);
-			items.fence = TerrestriaItems.register(name + "_fence", blocks.fence);
-			items.fenceGate = TerrestriaItems.register(name + "_fence_gate", blocks.fenceGate);
-			items.door = TerrestriaItems.register(name + "_door", blocks.door);
-			items.button = TerrestriaItems.register(name + "_button", blocks.button);
-			items.pressurePlate = TerrestriaItems.register(name + "_pressure_plate", blocks.pressurePlate);
-			items.trapdoor = TerrestriaItems.register(name + "_trapdoor", blocks.trapdoor);
-			items.sign = TerrestriaItems.registerSign(name + "_sign", blocks.sign, blocks.wallSign);
-			items.strippedLog = TerrestriaItems.register("stripped_" + name + "_log", blocks.strippedLog);
-
-			return items;
-		}
+		BASALT = TerrestriaRegistry.registerBlockItem("basalt", TerrestriaBlocks.BASALT);
+		BASALT_SAND = TerrestriaRegistry.registerBlockItem("basalt_sand", TerrestriaBlocks.BASALT_SAND);
+		BASALT_DIRT = TerrestriaRegistry.registerBlockItem("basalt_dirt", TerrestriaBlocks.BASALT_DIRT);
+		BASALT_GRASS_BLOCK = TerrestriaRegistry.registerBlockItem("basalt_grass_block", TerrestriaBlocks.BASALT_GRASS_BLOCK);
+		INDIAN_PAINTBRUSH = TerrestriaRegistry.registerBlockItem("indian_paintbrush", TerrestriaBlocks.INDIAN_PAINTBRUSH);
+		MONSTERAS = TerrestriaRegistry.registerBlockItem("monsteras", TerrestriaBlocks.MONSTERAS);
 	}
 }

--- a/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/TerrestriaItems.java
@@ -59,7 +59,6 @@ public class TerrestriaItems {
 		WILLOW = WoodItems.register("willow", TerrestriaBlocks.WILLOW);
 		JAPANESE_MAPLE = WoodItems.register("japanese_maple", TerrestriaBlocks.JAPANESE_MAPLE);
 		RAINBOW_EUCALYPTUS = WoodItems.register("rainbow_eucalyptus", TerrestriaBlocks.RAINBOW_EUCALYPTUS);
-		PALM = WoodItems.register("palm", TerrestriaBlocks.PALM);
 		SAKURA = WoodItems.registerWithoutBark("sakura", TerrestriaBlocks.SAKURA);
 		SAKURA.wood = SAKURA.log;
 

--- a/src/main/java/net/coderbot/terrestria/init/helpers/TerrestriaRegistry.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/TerrestriaRegistry.java
@@ -1,0 +1,24 @@
+package net.coderbot.terrestria.init.helpers;
+
+import net.coderbot.terrestria.Terrestria;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.SignItem;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class TerrestriaRegistry {
+
+	public static BlockItem registerBlockItem(String name, Block block) {
+		return net.minecraft.util.registry.Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new BlockItem(block, new Item.Settings().group(Terrestria.ITEM_GROUP)));
+	}
+
+	public static SignItem registerSign(String name, Block standing, Block wall) {
+		return net.minecraft.util.registry.Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new SignItem(new Item.Settings().group(Terrestria.ITEM_GROUP), standing, wall));
+	}
+
+	public static <T extends Block> T registerBlock(String name, T block) {
+		return Registry.register(Registry.BLOCK, new Identifier(Terrestria.MOD_ID, name), block);
+	}
+}

--- a/src/main/java/net/coderbot/terrestria/init/helpers/TerrestriaRegistry.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/TerrestriaRegistry.java
@@ -11,14 +11,14 @@ import net.minecraft.util.registry.Registry;
 public class TerrestriaRegistry {
 
 	public static BlockItem registerBlockItem(String name, Block block) {
-		return net.minecraft.util.registry.Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new BlockItem(block, new Item.Settings().group(Terrestria.ITEM_GROUP)));
+		return Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new BlockItem(block, new Item.Settings().group(Terrestria.ITEM_GROUP)));
 	}
 
-	public static SignItem registerSign(String name, Block standing, Block wall) {
-		return net.minecraft.util.registry.Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new SignItem(new Item.Settings().group(Terrestria.ITEM_GROUP), standing, wall));
+	public static SignItem registerSignItem(String name, Block standing, Block wall) {
+		return Registry.register(net.minecraft.util.registry.Registry.ITEM, new Identifier(Terrestria.MOD_ID, name), new SignItem(new Item.Settings().group(Terrestria.ITEM_GROUP), standing, wall));
 	}
 
-	public static <T extends Block> T registerBlock(String name, T block) {
+	public static <T extends Block> T register(String name, T block) {
 		return Registry.register(Registry.BLOCK, new Identifier(Terrestria.MOD_ID, name), block);
 	}
 }

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
@@ -59,10 +59,10 @@ public class WoodBlocks {
 			WoodBlocks blocks = registerManufactured(name, colors, registry);
 
 			blocks.log = TerrestriaRegistry.registerBlock(name + "_log", new SmallLogBlock(blocks.leaves, () -> blocks.strippedLog, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-			blocks.wood = TerrestriaRegistry.registerBlock(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+			blocks.wood = blocks.log; //no need for a wood type
 			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new TransparentLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
 			blocks.strippedLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_log", new SmallLogBlock(blocks.leaves, null, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-			blocks.strippedWood = blocks.strippedLog;
+			blocks.strippedWood = blocks.strippedLog; //no need for a stripped wood type
 
 			blocks.addTreeFireInfo(registry);
 

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
@@ -35,15 +35,15 @@ public class WoodBlocks {
 	public static WoodBlocks register(String name, WoodColors colors, FlammableBlockRegistry registry, boolean useExtendedLeaves) {
 		WoodBlocks blocks = registerManufactured(name, colors, registry);
 
-		blocks.log = TerrestriaRegistry.registerBlock(name + "_log", new StrippableLogBlock(() -> blocks.strippedLog, colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
-		blocks.wood = TerrestriaRegistry.registerBlock(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+		blocks.log = TerrestriaRegistry.register(name + "_log", new StrippableLogBlock(() -> blocks.strippedLog, colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+		blocks.wood = TerrestriaRegistry.register(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
 		if (useExtendedLeaves) {
-			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new ExtendedLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+			blocks.leaves = TerrestriaRegistry.register(name + "_leaves", new ExtendedLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
 		} else {
-			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+			blocks.leaves = TerrestriaRegistry.register(name + "_leaves", new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
 		}
-		blocks.strippedLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_log", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
-		blocks.strippedWood = TerrestriaRegistry.registerBlock("stripped_" + name + "_wood", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+		blocks.strippedLog = TerrestriaRegistry.register("stripped_" + name + "_log", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+		blocks.strippedWood = TerrestriaRegistry.register("stripped_" + name + "_wood", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
 
 		blocks.addTreeFireInfo(registry);
 
@@ -58,10 +58,10 @@ public class WoodBlocks {
 		if (size.equals(LogSize.SMALL)) {
 			WoodBlocks blocks = registerManufactured(name, colors, registry);
 
-			blocks.log = TerrestriaRegistry.registerBlock(name + "_log", new SmallLogBlock(blocks.leaves, () -> blocks.strippedLog, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+			blocks.log = TerrestriaRegistry.register(name + "_log", new SmallLogBlock(blocks.leaves, () -> blocks.strippedLog, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
 			blocks.wood = blocks.log; //no need for a wood type
-			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new TransparentLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
-			blocks.strippedLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_log", new SmallLogBlock(blocks.leaves, null, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+			blocks.leaves = TerrestriaRegistry.register(name + "_leaves", new TransparentLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+			blocks.strippedLog = TerrestriaRegistry.register("stripped_" + name + "_log", new SmallLogBlock(blocks.leaves, null, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
 			blocks.strippedWood = blocks.strippedLog; //no need for a stripped wood type
 
 			blocks.addTreeFireInfo(registry);
@@ -77,20 +77,20 @@ public class WoodBlocks {
 		blocks.name = name;
 		blocks.colors = colors;
 
-		blocks.planks = TerrestriaRegistry.registerBlock(name + "_planks", new Block(FabricBlockSettings.copy(Blocks.OAK_PLANKS).materialColor(colors.planks).build()));
-		blocks.slab = TerrestriaRegistry.registerBlock(name + "_slab", new SlabBlock(FabricBlockSettings.copy(Blocks.OAK_SLAB).materialColor(colors.planks).build()));
-		blocks.stairs = TerrestriaRegistry.registerBlock(name + "_stairs", new TerraformStairsBlock(blocks.planks, FabricBlockSettings.copy(Blocks.OAK_STAIRS).materialColor(colors.planks).build()));
-		blocks.fence = TerrestriaRegistry.registerBlock(name + "_fence", new FenceBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE).materialColor(colors.planks).build()));
-		blocks.fenceGate = TerrestriaRegistry.registerBlock(name + "_fence_gate", new FenceGateBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
-		blocks.door = TerrestriaRegistry.registerBlock(name + "_door", new TerraformDoorBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
-		blocks.button = TerrestriaRegistry.registerBlock(name + "_button", new TerraformButtonBlock(FabricBlockSettings.copy(Blocks.OAK_BUTTON).materialColor(colors.planks).build()));
-		blocks.pressurePlate = TerrestriaRegistry.registerBlock(name + "_pressure_plate", new TerraformPressurePlateBlock(FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).materialColor(colors.planks).build()));
-		blocks.trapdoor = TerrestriaRegistry.registerBlock(name + "_trapdoor", new TerraformTrapdoorBlock(FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).materialColor(colors.planks).build()));
+		blocks.planks = TerrestriaRegistry.register(name + "_planks", new Block(FabricBlockSettings.copy(Blocks.OAK_PLANKS).materialColor(colors.planks).build()));
+		blocks.slab = TerrestriaRegistry.register(name + "_slab", new SlabBlock(FabricBlockSettings.copy(Blocks.OAK_SLAB).materialColor(colors.planks).build()));
+		blocks.stairs = TerrestriaRegistry.register(name + "_stairs", new TerraformStairsBlock(blocks.planks, FabricBlockSettings.copy(Blocks.OAK_STAIRS).materialColor(colors.planks).build()));
+		blocks.fence = TerrestriaRegistry.register(name + "_fence", new FenceBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE).materialColor(colors.planks).build()));
+		blocks.fenceGate = TerrestriaRegistry.register(name + "_fence_gate", new FenceGateBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
+		blocks.door = TerrestriaRegistry.register(name + "_door", new TerraformDoorBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
+		blocks.button = TerrestriaRegistry.register(name + "_button", new TerraformButtonBlock(FabricBlockSettings.copy(Blocks.OAK_BUTTON).materialColor(colors.planks).build()));
+		blocks.pressurePlate = TerrestriaRegistry.register(name + "_pressure_plate", new TerraformPressurePlateBlock(FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).materialColor(colors.planks).build()));
+		blocks.trapdoor = TerrestriaRegistry.register(name + "_trapdoor", new TerraformTrapdoorBlock(FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).materialColor(colors.planks).build()));
 
 		Identifier signTexture = new Identifier(Terrestria.MOD_ID, "textures/entity/signs/" + name + ".png");
 
-		blocks.sign = TerrestriaRegistry.registerBlock(name + "_sign", new TerraformSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
-		blocks.wallSign = TerrestriaRegistry.registerBlock(name + "_wall_sign", new TerraformWallSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
+		blocks.sign = TerrestriaRegistry.register(name + "_sign", new TerraformSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
+		blocks.wallSign = TerrestriaRegistry.register(name + "_wall_sign", new TerraformWallSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
 
 		blocks.addManufacturedFireInfo(registry);
 
@@ -98,7 +98,7 @@ public class WoodBlocks {
 	}
 
 	public QuarterLogBlock registerQuarterLog(Supplier<Block> stripped, FlammableBlockRegistry registry) {
-		QuarterLogBlock quarterLog = TerrestriaRegistry.registerBlock(name + "_quarter_log", new QuarterLogBlock(stripped, colors.planks, Block.Settings.copy(log)));
+		QuarterLogBlock quarterLog = TerrestriaRegistry.register(name + "_quarter_log", new QuarterLogBlock(stripped, colors.planks, Block.Settings.copy(log)));
 
 		registry.add(quarterLog, 5, 5);
 
@@ -106,7 +106,7 @@ public class WoodBlocks {
 	}
 
 	public QuarterLogBlock registerStrippedQuarterLog(FlammableBlockRegistry registry) {
-		QuarterLogBlock quarterLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_quarter_log", new QuarterLogBlock(null, colors.planks, Block.Settings.copy(strippedLog)));
+		QuarterLogBlock quarterLog = TerrestriaRegistry.register("stripped_" + name + "_quarter_log", new QuarterLogBlock(null, colors.planks, Block.Settings.copy(strippedLog)));
 
 		registry.add(quarterLog, 5, 5);
 

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodBlocks.java
@@ -1,0 +1,157 @@
+package net.coderbot.terrestria.init.helpers;
+
+import io.github.terraformersmc.terraform.block.*;
+import net.coderbot.terrestria.Terrestria;
+import net.coderbot.terrestria.feature.TreeDefinition;
+import net.fabricmc.fabric.api.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Supplier;
+
+public class WoodBlocks {
+	public Block log;
+	public Block wood;
+	public Block leaves;
+	public Block planks;
+	public SlabBlock slab;
+	public TerraformStairsBlock stairs;
+	public FenceBlock fence;
+	public FenceGateBlock fenceGate;
+	public TerraformDoorBlock door;
+	public TerraformButtonBlock button;
+	public TerraformPressurePlateBlock pressurePlate;
+	public TerraformSignBlock sign;
+	public TerraformWallSignBlock wallSign;
+	public TerraformTrapdoorBlock trapdoor;
+	public Block strippedLog;
+	public Block strippedWood;
+	private String name;
+	private WoodColors colors;
+
+	public WoodBlocks() {}
+
+	public static WoodBlocks register(String name, WoodColors colors, FlammableBlockRegistry registry, boolean useExtendedLeaves) {
+		WoodBlocks blocks = registerManufactured(name, colors, registry);
+
+		blocks.log = TerrestriaRegistry.registerBlock(name + "_log", new StrippableLogBlock(() -> blocks.strippedLog, colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+		blocks.wood = TerrestriaRegistry.registerBlock(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+		if (useExtendedLeaves) {
+			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new ExtendedLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+		} else {
+			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new LeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+		}
+		blocks.strippedLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_log", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+		blocks.strippedWood = TerrestriaRegistry.registerBlock("stripped_" + name + "_wood", new LogBlock(colors.planks, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+
+		blocks.addTreeFireInfo(registry);
+
+		return blocks;
+	}
+
+	public static WoodBlocks register(String name, WoodColors colors, FlammableBlockRegistry registry) {
+		return register(name, colors, registry, false);
+	}
+
+	public static WoodBlocks register(String name, WoodColors colors, FlammableBlockRegistry registry, LogSize size) {
+		if (size.equals(LogSize.SMALL)) {
+			WoodBlocks blocks = registerManufactured(name, colors, registry);
+
+			blocks.log = TerrestriaRegistry.registerBlock(name + "_log", new SmallLogBlock(blocks.leaves, () -> blocks.strippedLog, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+			blocks.wood = TerrestriaRegistry.registerBlock(name + "_wood", new StrippableLogBlock(() -> blocks.strippedWood, colors.bark, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.bark).build()));
+			blocks.leaves = TerrestriaRegistry.registerBlock(name + "_leaves", new TransparentLeavesBlock(FabricBlockSettings.copy(Blocks.OAK_LEAVES).materialColor(colors.leaves).build()));
+			blocks.strippedLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_log", new SmallLogBlock(blocks.leaves, null, FabricBlockSettings.copy(Blocks.OAK_LOG).materialColor(colors.planks).build()));
+			blocks.strippedWood = blocks.strippedLog;
+
+			blocks.addTreeFireInfo(registry);
+
+			return blocks;
+		} else {
+			return register(name, colors, registry, false);
+		}
+	}
+
+	public static WoodBlocks registerManufactured(String name, WoodColors colors, FlammableBlockRegistry registry) {
+		WoodBlocks blocks = new WoodBlocks();
+		blocks.name = name;
+		blocks.colors = colors;
+
+		blocks.planks = TerrestriaRegistry.registerBlock(name + "_planks", new Block(FabricBlockSettings.copy(Blocks.OAK_PLANKS).materialColor(colors.planks).build()));
+		blocks.slab = TerrestriaRegistry.registerBlock(name + "_slab", new SlabBlock(FabricBlockSettings.copy(Blocks.OAK_SLAB).materialColor(colors.planks).build()));
+		blocks.stairs = TerrestriaRegistry.registerBlock(name + "_stairs", new TerraformStairsBlock(blocks.planks, FabricBlockSettings.copy(Blocks.OAK_STAIRS).materialColor(colors.planks).build()));
+		blocks.fence = TerrestriaRegistry.registerBlock(name + "_fence", new FenceBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE).materialColor(colors.planks).build()));
+		blocks.fenceGate = TerrestriaRegistry.registerBlock(name + "_fence_gate", new FenceGateBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
+		blocks.door = TerrestriaRegistry.registerBlock(name + "_door", new TerraformDoorBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).materialColor(colors.planks).build()));
+		blocks.button = TerrestriaRegistry.registerBlock(name + "_button", new TerraformButtonBlock(FabricBlockSettings.copy(Blocks.OAK_BUTTON).materialColor(colors.planks).build()));
+		blocks.pressurePlate = TerrestriaRegistry.registerBlock(name + "_pressure_plate", new TerraformPressurePlateBlock(FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).materialColor(colors.planks).build()));
+		blocks.trapdoor = TerrestriaRegistry.registerBlock(name + "_trapdoor", new TerraformTrapdoorBlock(FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).materialColor(colors.planks).build()));
+
+		Identifier signTexture = new Identifier(Terrestria.MOD_ID, "textures/entity/signs/" + name + ".png");
+
+		blocks.sign = TerrestriaRegistry.registerBlock(name + "_sign", new TerraformSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
+		blocks.wallSign = TerrestriaRegistry.registerBlock(name + "_wall_sign", new TerraformWallSignBlock(signTexture, FabricBlockSettings.copy(Blocks.OAK_SIGN).materialColor(colors.planks).build()));
+
+		blocks.addManufacturedFireInfo(registry);
+
+		return blocks;
+	}
+
+	public QuarterLogBlock registerQuarterLog(Supplier<Block> stripped, FlammableBlockRegistry registry) {
+		QuarterLogBlock quarterLog = TerrestriaRegistry.registerBlock(name + "_quarter_log", new QuarterLogBlock(stripped, colors.planks, Block.Settings.copy(log)));
+
+		registry.add(quarterLog, 5, 5);
+
+		return quarterLog;
+	}
+
+	public QuarterLogBlock registerStrippedQuarterLog(FlammableBlockRegistry registry) {
+		QuarterLogBlock quarterLog = TerrestriaRegistry.registerBlock("stripped_" + name + "_quarter_log", new QuarterLogBlock(null, colors.planks, Block.Settings.copy(strippedLog)));
+
+		registry.add(quarterLog, 5, 5);
+
+		return quarterLog;
+	}
+
+	public void addTreeFireInfo(FlammableBlockRegistry registry) {
+		registry.add(log, 5, 5);
+		registry.add(strippedLog, 5, 5);
+
+		if (wood != log) {
+			registry.add(wood, 5, 5);
+		}
+
+		if (strippedWood != strippedLog) {
+			registry.add(strippedWood, 5, 5);
+		}
+
+		registry.add(leaves, 30, 60);
+	}
+
+	public void addManufacturedFireInfo(FlammableBlockRegistry registry) {
+		registry.add(planks, 5, 20);
+		registry.add(slab, 5, 20);
+		registry.add(stairs, 5, 20);
+		registry.add(fence, 5, 20);
+		registry.add(fenceGate, 5, 20);
+	}
+
+	public TreeDefinition.Basic getBasicDefinition() {
+		return new TreeDefinition.Basic(this.log.getDefaultState(), this.leaves.getDefaultState());
+	}
+
+	public enum LogSize {
+		LARGE("large"),
+		SMALL("small");
+
+		private final String name;
+
+		LogSize(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+	}
+}

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodColors.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodColors.java
@@ -2,8 +2,6 @@ package net.coderbot.terrestria.init.helpers;
 
 import net.minecraft.block.MaterialColor;
 
-//This is also doo doo, should be done in line with the block's registry
-//or better yet calculated from the texture
 public class WoodColors {
 	public static final WoodColors REDWOOD;
 	public static final WoodColors HEMLOCK;

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodColors.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodColors.java
@@ -1,0 +1,57 @@
+package net.coderbot.terrestria.init.helpers;
+
+import net.minecraft.block.MaterialColor;
+
+//This is also doo doo, should be done in line with the block's registry
+//or better yet calculated from the texture
+public class WoodColors {
+	public static final WoodColors REDWOOD;
+	public static final WoodColors HEMLOCK;
+	public static final WoodColors RUBBER;
+	public static final WoodColors CYPRESS;
+	public static final WoodColors WILLOW;
+	public static final WoodColors JAPANESE_MAPLE;
+	public static final WoodColors RAINBOW_EUCALYPTUS;
+	public static final WoodColors SAKURA;
+
+	static {
+		REDWOOD = new WoodColors();
+		REDWOOD.bark = MaterialColor.RED_TERRACOTTA;
+		REDWOOD.planks = MaterialColor.WOOD;
+
+		HEMLOCK = new WoodColors();
+		HEMLOCK.bark = MaterialColor.BROWN;
+		HEMLOCK.planks = MaterialColor.WOOD;
+
+		RUBBER = new WoodColors();
+		RUBBER.bark = MaterialColor.WHITE_TERRACOTTA;
+		RUBBER.planks = MaterialColor.SAND;
+
+		CYPRESS = new WoodColors();
+		CYPRESS.bark = MaterialColor.WHITE_TERRACOTTA;
+		CYPRESS.planks = MaterialColor.LIGHT_GRAY;
+
+		WILLOW = new WoodColors();
+		WILLOW.bark = MaterialColor.WHITE_TERRACOTTA;
+		WILLOW.planks = MaterialColor.GRAY;
+		WILLOW.leaves = MaterialColor.LIGHT_GRAY;
+
+		JAPANESE_MAPLE = new WoodColors();
+		JAPANESE_MAPLE.bark = MaterialColor.BROWN;
+		JAPANESE_MAPLE.planks = MaterialColor.MAGENTA_TERRACOTTA;
+		JAPANESE_MAPLE.leaves = MaterialColor.RED;
+
+		RAINBOW_EUCALYPTUS = new WoodColors();
+		RAINBOW_EUCALYPTUS.bark = MaterialColor.BLUE;
+		RAINBOW_EUCALYPTUS.planks = MaterialColor.LAPIS;
+
+		SAKURA = new WoodColors();
+		SAKURA.bark = MaterialColor.SPRUCE;
+		SAKURA.planks = MaterialColor.BROWN;
+		SAKURA.leaves = MaterialColor.PINK;
+	}
+
+	public MaterialColor bark;
+	public MaterialColor planks;
+	public MaterialColor leaves = MaterialColor.FOLIAGE;
+}

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
@@ -25,17 +25,6 @@ public class WoodItems {
 	}
 
 	public static WoodItems register(String name, WoodBlocks blocks) {
-		WoodItems items = registerWithoutBark(name, blocks);
-
-		items.wood = TerrestriaRegistry.registerBlockItem(name + "_wood", blocks.wood);
-		items.strippedWood = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_wood", blocks.strippedWood);
-
-		return items;
-	}
-
-	//Used for sakura since it uses small logs
-	//This is kinda dumb, should be modularized a bit better.
-	public static WoodItems registerWithoutBark(String name, WoodBlocks blocks) {
 		WoodItems items = new WoodItems();
 
 		items.log = TerrestriaRegistry.registerBlockItem(name + "_log", blocks.log);
@@ -51,6 +40,13 @@ public class WoodItems {
 		items.trapdoor = TerrestriaRegistry.registerBlockItem(name + "_trapdoor", blocks.trapdoor);
 		items.sign = TerrestriaRegistry.registerSign(name + "_sign", blocks.sign, blocks.wallSign);
 		items.strippedLog = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_log", blocks.strippedLog);
+
+		if (blocks.log != blocks.wood) {
+			items.wood = TerrestriaRegistry.registerBlockItem(name + "_wood", blocks.wood);
+		}
+		if (blocks.strippedLog != blocks.strippedWood) {
+			items.strippedWood = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_wood", blocks.strippedWood);
+		}
 
 		return items;
 	}

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
@@ -1,0 +1,57 @@
+package net.coderbot.terrestria.init.helpers;
+
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.SignItem;
+
+public class WoodItems {
+
+	public BlockItem log;
+	public BlockItem wood;
+	public BlockItem leaves;
+	public BlockItem planks;
+	public BlockItem slab;
+	public BlockItem stairs;
+	public BlockItem fence;
+	public BlockItem fenceGate;
+	public BlockItem door;
+	public BlockItem button;
+	public BlockItem pressurePlate;
+	public SignItem sign;
+	public BlockItem trapdoor;
+	public BlockItem strippedLog;
+	public BlockItem strippedWood;
+
+	private WoodItems() {
+	}
+
+	public static WoodItems register(String name, WoodBlocks blocks) {
+		WoodItems items = registerWithoutBark(name, blocks);
+
+		items.wood = TerrestriaRegistry.registerBlockItem(name + "_wood", blocks.wood);
+		items.strippedWood = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_wood", blocks.strippedWood);
+
+		return items;
+	}
+
+	//Used for sakura since it uses small logs
+	//This is kinda dumb, should be modularized a bit better.
+	public static WoodItems registerWithoutBark(String name, WoodBlocks blocks) {
+		WoodItems items = new WoodItems();
+
+		items.log = TerrestriaRegistry.registerBlockItem(name + "_log", blocks.log);
+		items.leaves = TerrestriaRegistry.registerBlockItem(name + "_leaves", blocks.leaves);
+		items.planks = TerrestriaRegistry.registerBlockItem(name + "_planks", blocks.planks);
+		items.slab = TerrestriaRegistry.registerBlockItem(name + "_slab", blocks.slab);
+		items.stairs = TerrestriaRegistry.registerBlockItem(name + "_stairs", blocks.stairs);
+		items.fence = TerrestriaRegistry.registerBlockItem(name + "_fence", blocks.fence);
+		items.fenceGate = TerrestriaRegistry.registerBlockItem(name + "_fence_gate", blocks.fenceGate);
+		items.door = TerrestriaRegistry.registerBlockItem(name + "_door", blocks.door);
+		items.button = TerrestriaRegistry.registerBlockItem(name + "_button", blocks.button);
+		items.pressurePlate = TerrestriaRegistry.registerBlockItem(name + "_pressure_plate", blocks.pressurePlate);
+		items.trapdoor = TerrestriaRegistry.registerBlockItem(name + "_trapdoor", blocks.trapdoor);
+		items.sign = TerrestriaRegistry.registerSign(name + "_sign", blocks.sign, blocks.wallSign);
+		items.strippedLog = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_log", blocks.strippedLog);
+
+		return items;
+	}
+}

--- a/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
+++ b/src/main/java/net/coderbot/terrestria/init/helpers/WoodItems.java
@@ -38,7 +38,7 @@ public class WoodItems {
 		items.button = TerrestriaRegistry.registerBlockItem(name + "_button", blocks.button);
 		items.pressurePlate = TerrestriaRegistry.registerBlockItem(name + "_pressure_plate", blocks.pressurePlate);
 		items.trapdoor = TerrestriaRegistry.registerBlockItem(name + "_trapdoor", blocks.trapdoor);
-		items.sign = TerrestriaRegistry.registerSign(name + "_sign", blocks.sign, blocks.wallSign);
+		items.sign = TerrestriaRegistry.registerSignItem(name + "_sign", blocks.sign, blocks.wallSign);
 		items.strippedLog = TerrestriaRegistry.registerBlockItem("stripped_" + name + "_log", blocks.strippedLog);
 
 		if (blocks.log != blocks.wood) {


### PR DESCRIPTION
The goal of this PR is to make the init classes register things only, separates inner helper classes into a separate package "init.helpers" and also makes a few of the exception registry cases their own register options, namely small logged trees. can be registered by feeding an LogSize enum into the register method as a parameter.