### PR TITLE
Explicitly declare that older (legacy) versions of Traverse / Cinderscapes / Terraform are not supported

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,6 +43,12 @@
     "terraform-tree-api-v1": ">=1.0.0",
     "terraform-wood-api-v1": ">=1.0.0"
   },
+  "breaks": {
+    "terraform-legacy-v0": "*",
+    "terraform": "*",
+    "traverse": "<=3.0.0",
+    "cinderscapes": "<=1.2.3"
+  },
   "mixins": [
     "mixins.terrestria.json",
     "mixins.terrestria.pathing.json"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -46,8 +46,9 @@
   "breaks": {
     "terraform-legacy-v0": "*",
     "terraform": "*",
-    "traverse": "<=3.0.0",
-    "cinderscapes": "<=1.2.3"
+    "campanion": "<1.2.0",
+    "traverse": "<3.0.0",
+    "cinderscapes": "<1.2.3"
   },
   "mixins": [
     "mixins.terrestria.json",


### PR DESCRIPTION
Users have reported cryptic crashes with these versions. An explicit "breaks" declaration seems a lot more intuitive.

Note: I haven't actually tested this change. It would be good to test this at least once before merging.