### PR TITLE
Upgrade to new terraform-dirt-api version to fix bug with farmland reverting to vanilla dirt

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ libstructure_version=1.5
 # Terraform modules
 terraform_biome_builder_api_version=1.0.0+build.1
 terraform_config_api_version=1.0.0+build.1
-terraform_dirt_version=1.0.0+build.1
+terraform_dirt_version=1.1.0+build.4
 terraform_overworld_biome_extensions_version=1.0.0+build.1
 terraform_shapes_api_version=1.0.0+build.1
 terraform_surfaces_api_version=1.0.0+build.1

--- a/src/main/java/com/terraformersmc/terrestria/init/TerrestriaBlocks.java
+++ b/src/main/java/com/terraformersmc/terrestria/init/TerrestriaBlocks.java
@@ -175,7 +175,7 @@ public class TerrestriaBlocks {
 			TerrestriaRegistry.register("basalt_grass_block", new BasaltGrassBlock(andisolDirt, () -> ANDISOL.getGrassPath(), FabricBlockSettings.copyOf(Blocks.GRASS_BLOCK).breakByTool(FabricToolTags.SHOVELS, 0))),
 			TerrestriaRegistry.register("basalt_grass_path", new TerraformGrassPathBlock(andisolDirt, FabricBlockSettings.copyOf(Blocks.GRASS_PATH).breakByTool(FabricToolTags.SHOVELS, 0))),
 			TerrestriaRegistry.register("basalt_podzol", new TerraformSnowyBlock(FabricBlockSettings.copyOf(Blocks.PODZOL).breakByTool(FabricToolTags.SHOVELS, 0))),
-			TerrestriaRegistry.register("andisol_farmland", new TerraformFarmlandBlock(FabricBlockSettings.copyOf(Blocks.FARMLAND).materialColor(MaterialColor.BLACK).breakByTool(FabricToolTags.SHOVELS, 0), andisolDirt))
+			TerrestriaRegistry.register("andisol_farmland", new TerraformFarmlandBlock(FabricBlockSettings.copyOf(Blocks.FARMLAND).materialColor(MaterialColor.BLACK).breakByTool(FabricToolTags.SHOVELS, 0)))
 		));
 		VOLCANIC_ROCK = StoneBlocks.register("basalt", MaterialColor.BLACK);
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
     "libstructure": ">=1.5",
     "terraform-biome-builder-api-v1": ">=1.0.0",
     "terraform-config-api-v1": ">=1.0.0",
-    "terraform-dirt-api-v1": ">=1.0.0",
+    "terraform-dirt-api-v1": ">=1.1.0",
     "terraform-overworld-biome-extensions-api-v1": ">=1.0.0",
     "terraform-shapes-api-v1": ">=1.0.0",
     "terraform-surfaces-api-v1": ">=1.0.0",


### PR DESCRIPTION
This barely deserves a PR, but oh well.

Fixes #209