### PR TITLE
Restore quarter logs and roots on mega trees

### DIFF
--- a/src/main/java/com/terraformersmc/terrestria/feature/tree/treeconfigs/QuarteredMegaTreeConfig.java
+++ b/src/main/java/com/terraformersmc/terrestria/feature/tree/treeconfigs/QuarteredMegaTreeConfig.java
@@ -1,19 +1,63 @@
 package com.terraformersmc.terrestria.feature.tree.treeconfigs;
 
-import net.minecraft.block.BlockState;
+import java.util.List;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.world.Heightmap;
 import net.minecraft.world.gen.feature.TreeFeatureConfig;
+import net.minecraft.world.gen.feature.size.FeatureSize;
+import net.minecraft.world.gen.foliage.FoliagePlacer;
+import net.minecraft.world.gen.stateprovider.BlockStateProvider;
+import net.minecraft.world.gen.tree.TreeDecorator;
+import net.minecraft.world.gen.trunk.TrunkPlacer;
 
 public class QuarteredMegaTreeConfig extends TreeFeatureConfig {
+	// begin: vanilla copy
+	public static final Codec<QuarteredMegaTreeConfig> CODEC = RecordCodecBuilder.create((instance) -> {
+		return instance.group(
+				BlockStateProvider.TYPE_CODEC.fieldOf("trunk_provider").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.trunkProvider;
+		}), BlockStateProvider.TYPE_CODEC.fieldOf("leaves_provider").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.leavesProvider;
+		}), FoliagePlacer.TYPE_CODEC.fieldOf("foliage_placer").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.foliagePlacer;
+		}), TrunkPlacer.CODEC.fieldOf("trunk_placer").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.trunkPlacer;
+		}), FeatureSize.TYPE_CODEC.fieldOf("minimum_size").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.minimumSize;
+		}), TreeDecorator.TYPE_CODEC.listOf().fieldOf("decorators").forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.decorators;
+		}), Codec.INT.fieldOf("max_water_depth").orElse(0).forGetter((treeFeatureConfig) -> {
+			return treeFeatureConfig.maxWaterDepth;
+		}), Codec.BOOL.fieldOf("ignore_vines").orElse(false).forGetter(config -> config.ignoreVines),
+			Heightmap.Type.CODEC.fieldOf("heightmap").forGetter(config -> config.heightmap),
+			BlockStateProvider.TYPE_CODEC.fieldOf("quartered_trunk_provider").forGetter(config -> config.quarteredTrunkProvider),
+			BlockStateProvider.TYPE_CODEC.fieldOf("roots_provider").forGetter(config -> config.rootsProvider)
+		).apply(instance, QuarteredMegaTreeConfig::new);
+	});
+	// end: vanilla copy
 
-	public final BlockState quarterLogBlock;
-	public final BlockState logBlock;
-	public final BlockState woodBlock;
+	public final BlockStateProvider quarteredTrunkProvider;
+	public final BlockStateProvider rootsProvider;
 
-	public QuarteredMegaTreeConfig(TreeFeatureConfig config, BlockState quarterLogBlock, BlockState logBlock, BlockState woodBlock) {
+	protected QuarteredMegaTreeConfig(BlockStateProvider trunkProvider, BlockStateProvider leavesProvider,
+	                            FoliagePlacer foliagePlacer, TrunkPlacer trunkPlacer, FeatureSize minimumSize, 
+	                            List<TreeDecorator> decorators, int maxWaterDepth, boolean ignoreVines, 
+	                            Heightmap.Type heightmap, BlockStateProvider quarteredTrunkProvider,
+	                            BlockStateProvider rootsProvider) {
+		super(trunkProvider, leavesProvider, foliagePlacer, trunkPlacer, minimumSize, decorators, maxWaterDepth,
+				ignoreVines, heightmap);
+
+		this.quarteredTrunkProvider = quarteredTrunkProvider;
+		this.rootsProvider = rootsProvider;
+	}
+	
+	public QuarteredMegaTreeConfig(TreeFeatureConfig config, BlockStateProvider quarteredTrunkProvider, BlockStateProvider rootsProvider) {
 		super(config.trunkProvider, config.leavesProvider, config.foliagePlacer, config.trunkPlacer, config.minimumSize, config.decorators, config.maxWaterDepth, config.ignoreVines, config.heightmap);
 
-		this.quarterLogBlock = quarterLogBlock;
-		this.logBlock = logBlock;
-		this.woodBlock = woodBlock;
+		this.quarteredTrunkProvider = quarteredTrunkProvider;
+		this.rootsProvider = rootsProvider;
 	}
 }

--- a/src/main/java/com/terraformersmc/terrestria/feature/tree/treeconfigs/QuarteredMegaTreeConfig.java
+++ b/src/main/java/com/terraformersmc/terrestria/feature/tree/treeconfigs/QuarteredMegaTreeConfig.java
@@ -15,28 +15,21 @@ import net.minecraft.world.gen.trunk.TrunkPlacer;
 
 public class QuarteredMegaTreeConfig extends TreeFeatureConfig {
 	// begin: vanilla copy
-	public static final Codec<QuarteredMegaTreeConfig> CODEC = RecordCodecBuilder.create((instance) -> {
-		return instance.group(
-				BlockStateProvider.TYPE_CODEC.fieldOf("trunk_provider").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.trunkProvider;
-		}), BlockStateProvider.TYPE_CODEC.fieldOf("leaves_provider").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.leavesProvider;
-		}), FoliagePlacer.TYPE_CODEC.fieldOf("foliage_placer").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.foliagePlacer;
-		}), TrunkPlacer.CODEC.fieldOf("trunk_placer").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.trunkPlacer;
-		}), FeatureSize.TYPE_CODEC.fieldOf("minimum_size").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.minimumSize;
-		}), TreeDecorator.TYPE_CODEC.listOf().fieldOf("decorators").forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.decorators;
-		}), Codec.INT.fieldOf("max_water_depth").orElse(0).forGetter((treeFeatureConfig) -> {
-			return treeFeatureConfig.maxWaterDepth;
-		}), Codec.BOOL.fieldOf("ignore_vines").orElse(false).forGetter(config -> config.ignoreVines),
+	public static final Codec<QuarteredMegaTreeConfig> CODEC = RecordCodecBuilder.create (
+		instance -> instance.group (
+			BlockStateProvider.TYPE_CODEC.fieldOf("trunk_provider").forGetter(config -> config.trunkProvider),
+			BlockStateProvider.TYPE_CODEC.fieldOf("leaves_provider").forGetter(config -> config.leavesProvider),
+			FoliagePlacer.TYPE_CODEC.fieldOf("foliage_placer").forGetter(config -> config.foliagePlacer),
+			TrunkPlacer.CODEC.fieldOf("trunk_placer").forGetter(config -> config.trunkPlacer),
+			FeatureSize.TYPE_CODEC.fieldOf("minimum_size").forGetter(config -> config.minimumSize),
+			TreeDecorator.TYPE_CODEC.listOf().fieldOf("decorators").forGetter(config -> config.decorators),
+			Codec.INT.fieldOf("max_water_depth").orElse(0).forGetter(config -> config.maxWaterDepth),
+			Codec.BOOL.fieldOf("ignore_vines").orElse(false).forGetter(config -> config.ignoreVines),
 			Heightmap.Type.CODEC.fieldOf("heightmap").forGetter(config -> config.heightmap),
 			BlockStateProvider.TYPE_CODEC.fieldOf("quartered_trunk_provider").forGetter(config -> config.quarteredTrunkProvider),
 			BlockStateProvider.TYPE_CODEC.fieldOf("roots_provider").forGetter(config -> config.rootsProvider)
-		).apply(instance, QuarteredMegaTreeConfig::new);
-	});
+		).apply(instance, QuarteredMegaTreeConfig::new)
+	);
 	// end: vanilla copy
 
 	public final BlockStateProvider quarteredTrunkProvider;

--- a/src/main/java/com/terraformersmc/terrestria/feature/tree/trunkplacers/MegaTrunkPlacer.java
+++ b/src/main/java/com/terraformersmc/terrestria/feature/tree/trunkplacers/MegaTrunkPlacer.java
@@ -56,13 +56,13 @@ public class MegaTrunkPlacer extends TrunkPlacer {
 			setLog(world, mutable, set, blockBox, getState(random, mutable, treeFeatureConfig, QuarterLogBlock.BarkSide.SOUTHWEST), pos, 0, i, 1);
 		}
 
-		BlockStateProvider wood = treeFeatureConfig.trunkProvider;
+		BlockStateProvider rootsProvider = treeFeatureConfig.trunkProvider;
 
 		if (treeFeatureConfig instanceof QuarteredMegaTreeConfig) {
-			wood = new SimpleBlockStateProvider(((QuarteredMegaTreeConfig) treeFeatureConfig).woodBlock);
+			rootsProvider = ((QuarteredMegaTreeConfig) treeFeatureConfig).rootsProvider;
 		}
 
-		growRoots(set, world, pos.mutableCopy(), random, blockBox, wood);
+		growRoots(set, world, pos.mutableCopy(), random, blockBox, rootsProvider);
 
 		return ImmutableList.of(new FoliagePlacer.TreeNode(pos.up(trunkHeight), 0, true));
 	}
@@ -70,7 +70,7 @@ public class MegaTrunkPlacer extends TrunkPlacer {
 	static BlockState getState(Random random, BlockPos pos, TreeFeatureConfig config, QuarterLogBlock.BarkSide side) {
 		// TODO: Quarter logs aren't generated
 		if (config instanceof QuarteredMegaTreeConfig && Terrestria.getConfigManager().getGeneralConfig().areQuarterLogsEnabled()) {
-			return ((QuarteredMegaTreeConfig) config).quarterLogBlock.with(QuarterLogBlock.BARK_SIDE, side);
+			return ((QuarteredMegaTreeConfig) config).quarteredTrunkProvider.getBlockState(random, pos).with(QuarterLogBlock.BARK_SIDE, side);
 		} else {
 			return config.trunkProvider.getBlockState(random, pos);
 		}

--- a/src/main/java/com/terraformersmc/terrestria/init/TerrestriaConfiguredFeatures.java
+++ b/src/main/java/com/terraformersmc/terrestria/init/TerrestriaConfiguredFeatures.java
@@ -89,8 +89,8 @@ public class TerrestriaConfiguredFeatures {
 		HEMLOCK_TREE = registerTree("hemlock_tree", tallSpruceOf(TerrestriaBlocks.HEMLOCK, 24, 4, 3, 2, 5, 1, 11));
 		REDWOOD_TREE = registerTree("redwood_tree", tallSpruceOf(TerrestriaBlocks.REDWOOD, 24, 4, 3, 5, 2, 12, 7));
 
-		MEGA_HEMLOCK_TREE = registerTree("mega_hemlock_tree", giantSpruceOf(TerrestriaBlocks.HEMLOCK, 32, 8, 7, 2, 5, 1, 11));
-		MEGA_REDWOOD_TREE = registerTree("mega_redwood_tree", giantSpruceOf(TerrestriaBlocks.REDWOOD, 32, 8, 7, 2, 5, 12, 7));
+		MEGA_HEMLOCK_TREE = registerQuarteredMegaTree("mega_hemlock_tree", giantSpruceOf(TerrestriaBlocks.HEMLOCK, 32, 8, 7, 2, 5, 1, 11));
+		MEGA_REDWOOD_TREE = registerQuarteredMegaTree("mega_redwood_tree", giantSpruceOf(TerrestriaBlocks.REDWOOD, 32, 8, 7, 2, 5, 12, 7));
 		RUBBER_TREE = registerTree("rubber_tree", new TreeFeatureConfig.Builder(
 				new SimpleBlockStateProvider(TerrestriaBlocks.RUBBER.log.getDefaultState()),
 				new SimpleBlockStateProvider(TerrestriaBlocks.RUBBER.leaves.getDefaultState()),
@@ -114,7 +114,7 @@ public class TerrestriaConfiguredFeatures {
 		JAPANESE_MAPLE_SHRUB = registerTree("japanese_maple_shrub", shrubOf(TerrestriaBlocks.JAPANESE_MAPLE.log.getDefaultState(), TerrestriaBlocks.JAPANESE_MAPLE_SHRUB_LEAVES.getDefaultState()));
 		OAK_SHRUB = registerTree("oak_shrub", shrubOf(Blocks.OAK_LOG.getDefaultState(), Blocks.OAK_LEAVES.getDefaultState()));
 
-		RAINBOW_EUCALYPTUS_TREE = registerTree("rainbow_eucalyptus_tree", new QuarteredMegaTreeConfig(new TreeFeatureConfig.Builder(
+		RAINBOW_EUCALYPTUS_TREE = registerQuarteredMegaTree("rainbow_eucalyptus_tree", new QuarteredMegaTreeConfig(new TreeFeatureConfig.Builder(
 				new SimpleBlockStateProvider(TerrestriaBlocks.RAINBOW_EUCALYPTUS.log.getDefaultState()),
 				new SimpleBlockStateProvider(TerrestriaBlocks.RAINBOW_EUCALYPTUS.leaves.getDefaultState()),
 				new LargeOakFoliagePlacer(UniformIntDistribution.of(2), UniformIntDistribution.of(1), 2),
@@ -123,9 +123,8 @@ public class TerrestriaConfiguredFeatures {
 				.ignoreVines()
 				.maxWaterDepth(3)
 				.build(),
-				TerrestriaBlocks.RAINBOW_EUCALYPTUS.quarterLog.getDefaultState(),
-				TerrestriaBlocks.RAINBOW_EUCALYPTUS.log.getDefaultState(),
-				TerrestriaBlocks.RAINBOW_EUCALYPTUS.wood.getDefaultState()));
+				new SimpleBlockStateProvider(TerrestriaBlocks.RAINBOW_EUCALYPTUS.quarterLog.getDefaultState()),
+				new SimpleBlockStateProvider(TerrestriaBlocks.RAINBOW_EUCALYPTUS.wood.getDefaultState())));
 
 		SMALL_RAINBOW_EUCALYPTUS_SAPLING_TREE = registerTree("small_rainbow_eucalyptus_tree", (new TreeFeatureConfig.Builder(
 				new SimpleBlockStateProvider(TerrestriaBlocks.RAINBOW_EUCALYPTUS.log.getDefaultState()),
@@ -169,7 +168,7 @@ public class TerrestriaConfiguredFeatures {
 				new TwoLayersFeatureSize(1, 0, 1)
 		).build());
 
-		MEGA_CYPRESS_TREE = registerTree("mega_cypress_tree", new QuarteredMegaTreeConfig(new TreeFeatureConfig.Builder(
+		MEGA_CYPRESS_TREE = registerQuarteredMegaTree("mega_cypress_tree", new QuarteredMegaTreeConfig(new TreeFeatureConfig.Builder(
 				new SimpleBlockStateProvider(TerrestriaBlocks.CYPRESS.log.getDefaultState()),
 				new SimpleBlockStateProvider(TerrestriaBlocks.CYPRESS.leaves.getDefaultState()),
 				new LargeOakFoliagePlacer(UniformIntDistribution.of(3), UniformIntDistribution.of(2), 2),
@@ -178,9 +177,8 @@ public class TerrestriaConfiguredFeatures {
 				.ignoreVines()
 				.maxWaterDepth(6)
 				.build(),
-				TerrestriaBlocks.CYPRESS.quarterLog.getDefaultState(),
-				TerrestriaBlocks.CYPRESS.log.getDefaultState(),
-				TerrestriaBlocks.CYPRESS.wood.getDefaultState()));
+				new SimpleBlockStateProvider(TerrestriaBlocks.CYPRESS.quarterLog.getDefaultState()),
+				new SimpleBlockStateProvider(TerrestriaBlocks.CYPRESS.wood.getDefaultState())));
 
 		WILLOW_TREE = registerTree("willow_tree", canopyOf(TerrestriaBlocks.WILLOW, new CanopyTree4BranchTrunkPlacer(4, 1, 1), ImmutableList.of(new DanglingLeavesTreeDecorator(TerrestriaBlocks.WILLOW.leaves.getDefaultState()))));
 		YUCCA_PALM_TREE = registerSandyTree("yucca_palm_tree", new TreeFeatureConfig.Builder(
@@ -198,6 +196,15 @@ public class TerrestriaConfiguredFeatures {
 
 	private static ConfiguredFeature<TreeFeatureConfig, ?> registerTree(String name, TreeFeatureConfig config) {
 		ConfiguredFeature<TreeFeatureConfig, ?> configured = Feature.TREE.configure(config);
+		Identifier id = new Identifier(Terrestria.MOD_ID, name);
+
+		BuiltinRegistries.add(BuiltinRegistries.CONFIGURED_FEATURE, id, configured);
+
+		return configured;
+	}
+
+	private static ConfiguredFeature<TreeFeatureConfig, ?> registerQuarteredMegaTree(String name, QuarteredMegaTreeConfig config) {
+		ConfiguredFeature<TreeFeatureConfig, ?> configured = TerrestriaFeatures.QUARTERED_MEGA_TREE.configure(config);
 		Identifier id = new Identifier(Terrestria.MOD_ID, name);
 
 		BuiltinRegistries.add(BuiltinRegistries.CONFIGURED_FEATURE, id, configured);
@@ -302,18 +309,16 @@ public class TerrestriaConfiguredFeatures {
 				.build();
 	}
 
-	static TreeFeatureConfig giantSpruceOf(QuarteredWoodBlocks woodBlocks, int height, int randomHeight, int extraRandomHeight, int baseRadius, int randomRadius, int baseBareHeight, int randomBareHeight) {
+	static QuarteredMegaTreeConfig giantSpruceOf(QuarteredWoodBlocks woodBlocks, int height, int randomHeight, int extraRandomHeight, int baseRadius, int randomRadius, int baseBareHeight, int randomBareHeight) {
 		return new QuarteredMegaTreeConfig(new TreeFeatureConfig.Builder(
 				new SimpleBlockStateProvider(woodBlocks.log.getDefaultState()),
 				new SimpleBlockStateProvider(woodBlocks.leaves.getDefaultState()),
 				new PredictiveSpruceFoliagePlacer(UniformIntDistribution.of(baseRadius, randomRadius), UniformIntDistribution.of(0, 2), UniformIntDistribution.of(baseBareHeight, randomBareHeight)),
 				new MegaTrunkPlacer(height, randomHeight, extraRandomHeight),
 				new TwoLayersFeatureSize(2, 1, 2))
-
 				.ignoreVines()
 				.build(),
-				woodBlocks.quarterLog.getDefaultState(),
-				woodBlocks.log.getDefaultState(),
-				woodBlocks.wood.getDefaultState());
+				new SimpleBlockStateProvider(woodBlocks.quarterLog.getDefaultState()),
+				new SimpleBlockStateProvider(woodBlocks.wood.getDefaultState()));
 	}
 }

--- a/src/main/java/com/terraformersmc/terrestria/init/TerrestriaFeatures.java
+++ b/src/main/java/com/terraformersmc/terrestria/init/TerrestriaFeatures.java
@@ -1,8 +1,10 @@
 package com.terraformersmc.terrestria.init;
 
+import com.mojang.serialization.Codec;
 import com.terraformersmc.terrestria.Terrestria;
 import com.terraformersmc.terrestria.feature.CattailFeature;
 import com.terraformersmc.terrestria.feature.misc.DumDumHeadFeature;
+import com.terraformersmc.terrestria.feature.tree.treeconfigs.QuarteredMegaTreeConfig;
 
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
@@ -10,6 +12,7 @@ import net.minecraft.world.gen.ProbabilityConfig;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.FeatureConfig;
+import net.minecraft.world.gen.feature.TreeFeature;
 
 // This class exports public feature constants, these fields have to be public
 @SuppressWarnings("WeakerAccess")
@@ -17,10 +20,15 @@ public class TerrestriaFeatures {
 
 	public static CattailFeature CATTAIL;
 	public static Feature<DefaultFeatureConfig> DUM_DUM_HEAD;
+	public static TreeFeature QUARTERED_MEGA_TREE;
 
+	@SuppressWarnings({"rawtypes, unchecked"})
 	public static void init() {
 		CATTAIL = register("cattail", new CattailFeature(ProbabilityConfig.CODEC, TerrestriaBlocks.CATTAIL, TerrestriaBlocks.TALL_CATTAIL));
 		DUM_DUM_HEAD = register("dum_dum_head", new DumDumHeadFeature(DefaultFeatureConfig.CODEC));
+
+		// Super hacky casts, but it works
+		QUARTERED_MEGA_TREE = register("quartered_mega_tree", new TreeFeature((Codec) QuarteredMegaTreeConfig.CODEC));
 	}
 
 	public static <T extends Feature<FC>, FC extends FeatureConfig> T register(String name, T feature) {


### PR DESCRIPTION
This allows mega hemlock/redwood/cypress/rainbow eucalyptus trees to have roots and use quarter logs. We have to register a custom tree feature because otherwise the vanilla config codec is used, which completely ignores our custom tree feature config. As it turns out, we can just do some hacky casts and things work just fine. We still have to register our own tree feature, but it's just a different instance of the vanilla tree feature class, which works out nicely.

Fixes #187 