### PR TITLE
Allow crafting stripped wood from stripped logs

### DIFF
--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_cypress_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_cypress_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_cypress_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_cypress_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_cypress_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_hemlock_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_hemlock_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_hemlock_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_hemlock_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_hemlock_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_japanese_maple_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_japanese_maple_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_japanese_maple_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_japanese_maple_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_japanese_maple_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_rainbow_eucalyptus_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_rainbow_eucalyptus_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_rainbow_eucalyptus_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_rainbow_eucalyptus_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_rainbow_eucalyptus_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_redwood_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_redwood_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_redwood_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_redwood_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_redwood_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_rubber_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_rubber_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_rubber_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_rubber_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_rubber_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_willow_wood.json
+++ b/src/main/resources/data/terrestria/advancements/recipes/building_blocks/stripped_willow_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "terrestria:stripped_willow_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "terrestria:stripped_willow_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "terrestria:stripped_willow_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_cypress_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_cypress_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_cypress_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_cypress_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_hemlock_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_hemlock_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_hemlock_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_hemlock_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_japanese_maple_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_japanese_maple_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_japanese_maple_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_japanese_maple_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_rainbow_eucalyptus_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_rainbow_eucalyptus_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_rainbow_eucalyptus_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_rainbow_eucalyptus_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_redwood_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_redwood_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_redwood_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_redwood_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_rubber_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_rubber_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_rubber_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_rubber_wood",
+    "count": 3
+  }
+}

--- a/src/main/resources/data/terrestria/recipes/stripped_willow_wood.json
+++ b/src/main/resources/data/terrestria/recipes/stripped_willow_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "terrestria:stripped_willow_log"
+    }
+  },
+  "result": {
+    "item": "terrestria:stripped_willow_wood",
+    "count": 3
+  }
+}


### PR DESCRIPTION
Fixes #218

The following script was used to generate the crafting recipes:

```js
const fs = require("fs-extra");

const PATH_PATTERN = /^[a-z_]+_wood\.json$/;
const PATHS = [
	"src/main/resources/data/terrestria/recipes",
	"src/main/resources/data/terrestria/advancements/recipes/building_blocks"
];

(async () => {
	for (const path of PATHS) {
		const files = await fs.readdir(path);
		for (const fileName of files) {
			if (fileName.match(PATH_PATTERN) && !fileName.startsWith("stripped")) {
				let file = await fs.readFile(path + "/" + fileName, "utf-8");
				file = file.replace(/\:([a-z_]+)_wood/g, ":stripped_$1_wood");
				file = file.replace(/\:([a-z_]+)_log/g, ":stripped_$1_log");
				file = file.replace(/has_log/g, "has_stripped_log");

				const destination = path + "/stripped_" + fileName;
				fs.writeFile(destination, file);
			}
		}
	}
})();
```