### PR TITLE
Add planks to #c:planks_that_burn (Blockus compatibility)

### DIFF
--- a/src/main/resources/data/c/tags/items/planks_that_burn.json
+++ b/src/main/resources/data/c/tags/items/planks_that_burn.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-	"terrestria:redwood_planks",
+    "terrestria:redwood_planks",
     "terrestria:hemlock_planks",
     "terrestria:rubber_planks",
     "terrestria:cypress_planks",
@@ -9,6 +9,6 @@
     "terrestria:rainbow_eucalyptus_planks",
     "terrestria:sakura_planks",
     "terrestria:willow_planks",
-	"terrestria:yucca_palm_planks"
+    "terrestria:yucca_palm_planks"
   ]
 }

--- a/src/main/resources/data/c/tags/items/planks_that_burn.json
+++ b/src/main/resources/data/c/tags/items/planks_that_burn.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+	"terrestria:redwood_planks",
+    "terrestria:hemlock_planks",
+    "terrestria:rubber_planks",
+    "terrestria:cypress_planks",
+    "terrestria:japanese_maple_planks",
+    "terrestria:rainbow_eucalyptus_planks",
+    "terrestria:sakura_planks",
+    "terrestria:willow_planks",
+	"terrestria:yucca_palm_planks"
+  ]
+}


### PR DESCRIPTION
This pull request adds all of Terrestria's planks to the tag `#c:planks_that_burn` so that they can be used in [Blockus'](https://github.com/Brandcraf06/Blockus) charred planks recipe.