### PR TITLE
Make LushDesert be in Desert Category instead of Ocean Category

### DIFF
--- a/src/main/java/com/terraformersmc/terrestria/biome/LushDesertBiomes.java
+++ b/src/main/java/com/terraformersmc/terrestria/biome/LushDesertBiomes.java
@@ -18,7 +18,7 @@ import static com.terraformersmc.terraform.biomebuilder.DefaultFeature.*;
 public class LushDesertBiomes {
 	public static void register() {
 		BiomeTemplate template = new BiomeTemplate(TerraformBiomeBuilder.create()
-				.precipitation(Biome.Precipitation.RAIN).category(Biome.Category.OCEAN)
+				.precipitation(Biome.Precipitation.RAIN).category(Biome.Category.DESERT)
 				.effects(TerrestriaBiomes.createDefaultBiomeEffects()
 					.waterColor(0x3f76e4)
 					.waterFogColor(0x50533)


### PR DESCRIPTION
Sneaky desert tried to be an ocean! But I can see through its disguise!

Basically, Ocean Category was causing my ocean dungeons to spawn in Lush Desert lol: https://github.com/TelepathicGrunt/RepurposedStructures-Fabric/issues/86

Closes #250 